### PR TITLE
Terminal: resync from history after stream gaps, walk on deleted sessions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -839,6 +839,13 @@ async def api_console_stream(session_id: str, user: dict = Depends(require_auth)
     return StreamingResponse(
         _proxy_session_events(session_id),
         media_type="text/event-stream",
+        headers={
+            # SSE must never be buffered by intermediaries — a buffered
+            # stream delivers events in delayed bursts and idle timeouts
+            # sever it mid-turn.
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -255,6 +255,9 @@
         const pendingQueue = []; // FIFO of {text, el, pill, sent} — queued while a turn is in flight
         let assistantDoneTimer = null;
         let destroyed = false;
+        let needsResync = false;   // stream dropped — repaint from history on reconnect
+        let resyncedMidTurn = false; // repainted while a turn was streaming — resync again at result
+        let resyncing = false;
 
         function queueFront() { return pendingQueue[0] || null; }
 
@@ -500,20 +503,36 @@
                 inFlight = false;
                 currentAssistantEl = null;
                 flushTtsNow();
+                if (resyncedMidTurn) {
+                    // The feed was rebuilt from history while this turn was
+                    // still streaming, so its earlier chunks are missing on
+                    // screen. Now that the turn is in the ledger, repaint.
+                    resyncedMidTurn = false;
+                    resyncFromHistory();
+                }
                 trySendFront();
             } else if (event.type === "session_closed") {
-                cancelAssistantDone();
-                currentAssistantEl = null;
-                inFlight = false;
-                // Keep the queue — the old session may never have received
-                // an unconfirmed front item, so mark it unsent and retry
-                // once reattached rather than dropping queued messages.
-                pendingQueue.forEach(function (item) { item.sent = false; });
-                sessionWasClosed = true;
-                disconnectStream();
-                beginReattachLoop();
+                handleSessionGone();
+            } else if (event.type === "system" && typeof event.content === "string" &&
+                       event.content.indexOf("upstream_error: 404") === 0) {
+                // Session row is gone on the gateway (deleted, not just
+                // rotated) — walk to a successor instead of reconnecting
+                // to a dead stream forever.
+                handleSessionGone();
             }
-            // tool events are intentionally ignored
+            // ping and tool events are intentionally ignored
+        }
+        function handleSessionGone() {
+            cancelAssistantDone();
+            currentAssistantEl = null;
+            inFlight = false;
+            // Keep the queue — the old session may never have received
+            // an unconfirmed front item, so mark it unsent and retry
+            // once reattached rather than dropping queued messages.
+            pendingQueue.forEach(function (item) { item.sent = false; });
+            sessionWasClosed = true;
+            disconnectStream();
+            beginReattachLoop();
         }
         function disconnectStream() {
             if (eventSource) { eventSource.close(); eventSource = null; }
@@ -521,16 +540,35 @@
         function connectStream(id) {
             disconnectStream();
             eventSource = new EventSource("/api/console/" + id + "/stream");
+            eventSource.onopen = function () {
+                // Events published while the stream was down are gone —
+                // the gateway keeps no observer history. Repaint from the
+                // durable turn ledger after every gap.
+                if (needsResync && sessionId === id && !destroyed && !sessionWasClosed) {
+                    needsResync = false;
+                    resyncFromHistory();
+                }
+            };
             eventSource.onmessage = function (msg) {
                 try { handleEvent(JSON.parse(msg.data)); } catch (e) {}
             };
             eventSource.onerror = function () {
                 if (sessionWasClosed || destroyed) return;
+                needsResync = true;
                 setTimeout(function () {
                     if (sessionId === id && !sessionWasClosed && !destroyed) connectStream(id);
                 }, 3000);
             };
         }
+        function onVisibilityChange() {
+            if (document.visibilityState !== "visible" || destroyed || sessionWasClosed || !sessionId) return;
+            // Mobile browsers suspend timers and sockets in background tabs;
+            // whatever streamed while suspended is lost. Catch up, and
+            // revive the stream if the browser silently killed it.
+            resyncFromHistory();
+            if (!eventSource || eventSource.readyState === 2) connectStream(sessionId);
+        }
+        document.addEventListener("visibilitychange", onVisibilityChange);
 
         function cancelReattachLoop() {
             if (reattachTimer) { clearTimeout(reattachTimer); reattachTimer = null; }
@@ -684,6 +722,64 @@
         backBtn.addEventListener("click", function () { closePanel(panel); });
 
         // ── history load + go live ────────────────────────────────
+        function paintHistoryRows(msgs) {
+            for (const m of msgs) {
+                const body = flattenContent(m.content);
+                if (!body) continue;
+                if (m.role === "user") {
+                    appendLine("term-user", "> " + body);
+                } else if (m.role === "assistant") {
+                    const line = document.createElement("div");
+                    line.className = "term-line term-assistant";
+                    line.dataset.prefix = (mindName || "mind") + " > ";
+                    line.textContent = line.dataset.prefix + body;
+                    feed.appendChild(line);
+                }
+            }
+            feed.scrollTop = feed.scrollHeight;
+        }
+        // Rebuild the feed from the durable turn ledger. Called after any
+        // stream gap: the gateway fans events out only to currently
+        // connected observers, so anything published during a gap never
+        // reaches this client any other way.
+        async function resyncFromHistory() {
+            if (resyncing || destroyed || !sessionId) return;
+            resyncing = true;
+            try {
+                const resp = await fetch("/api/terminal/session/" + sessionId + "/history", {credentials: "same-origin"});
+                if (!resp.ok) return;
+                const data = await resp.json();
+                const msgs = data.messages || [];
+                if (inFlight) resyncedMidTurn = true;
+                cancelAssistantDone();
+                currentAssistantEl = null;
+                feed.innerHTML = "";
+                paintHistoryRows(msgs);
+                // Confirm sent-but-unconfirmed queued messages that made it
+                // into the ledger (their echo event was lost with the gap).
+                const histUserTexts = msgs
+                    .filter(function (m) { return m.role === "user"; })
+                    .map(function (m) { return flattenContent(m.content); });
+                while (pendingQueue.length > 0 && pendingQueue[0].sent &&
+                       histUserTexts.indexOf(pendingQueue[0].text) !== -1) {
+                    pendingQueue.shift();
+                }
+                // Repaint what's still pending so queued sends stay visible.
+                pendingQueue.forEach(function (item) {
+                    const lineEl = document.createElement("div");
+                    lineEl.className = "term-line term-user term-pending";
+                    lineEl.textContent = "> " + item.text;
+                    item.el = lineEl;
+                    item.pill = null;
+                    feed.appendChild(lineEl);
+                });
+                feed.scrollTop = feed.scrollHeight;
+            } catch (e) {
+            } finally {
+                resyncing = false;
+            }
+            trySendFront();
+        }
         async function load() {
             applyLabel();
             deleteBtn.hidden = false;
@@ -692,20 +788,7 @@
                 if (resp.ok) {
                     const data = await resp.json();
                     const msgs = data.messages || [];
-                    for (const m of msgs) {
-                        const body = flattenContent(m.content);
-                        if (!body) continue;
-                        if (m.role === "user") {
-                            appendLine("term-user", "> " + body);
-                        } else if (m.role === "assistant") {
-                            const line = document.createElement("div");
-                            line.className = "term-line term-assistant";
-                            line.dataset.prefix = (mindName || "mind") + " > ";
-                            line.textContent = line.dataset.prefix + body;
-                            feed.appendChild(line);
-                            feed.scrollTop = feed.scrollHeight;
-                        }
-                    }
+                    paintHistoryRows(msgs);
                     if (msgs.length > 0) appendLine("term-system", "— history · live below —");
                 }
             } catch (e) {}
@@ -730,6 +813,7 @@
             },
             destroy: function () {
                 destroyed = true;
+                document.removeEventListener("visibilitychange", onVisibilityChange);
                 if (micTarget === panel) stopMic();
                 disconnectStream();
                 cancelReattachLoop();

--- a/tests/test_console_routes.py
+++ b/tests/test_console_routes.py
@@ -559,3 +559,79 @@ def test_terminal_session_create_uses_unique_client_ref_per_tile(tmp_path, monke
     assert all(ref.startswith("terminal-") for ref in refs)
     # owner_ref stays the stable surface label; only client_ref is per-tile.
     assert all(body["owner_ref"] == "terminal" for body in captured)
+
+
+def test_console_stream_sets_anti_buffering_headers(tmp_path, monkeypatch):
+    """SSE must carry no-cache/no-transform + X-Accel-Buffering headers so
+    intermediaries (Cloudflare) neither buffer nor transform the stream —
+    buffered SSE arrives in delayed bursts and loses events on idle cuts."""
+    client = _authed_client(tmp_path, monkeypatch)
+
+    async def fake_proxy(session_id):
+        yield "data: {\"type\":\"ping\"}\n\n"
+
+    with patch("main._proxy_session_events", side_effect=fake_proxy):
+        response = client.get("/api/console/sess-1/stream")
+
+    assert response.status_code == 200
+    assert "no-cache" in response.headers["cache-control"]
+    assert "no-transform" in response.headers["cache-control"]
+    assert response.headers["x-accel-buffering"] == "no"
+
+
+def test_proxy_session_events_passes_ping_through():
+    """Gateway heartbeat pings must reach the browser to keep the SSE
+    connection warm through proxy idle timeouts."""
+    lines = [
+        'data: {"type":"ping","session_id":"sess-1"}',
+        "",
+        'data: {"type":"assistant","content":"hi"}',
+        "",
+    ]
+    stream_cm = _FakeStreamResponse(lines)
+    fake_client = _FakeAsyncClient(stream_cm)
+    with patch("main.httpx.AsyncClient", return_value=fake_client):
+        events = asyncio.run(_collect(main_mod._proxy_session_events("sess-1")))
+
+    assert events[0] == 'data: {"type":"ping","session_id":"sess-1"}\n\n'
+
+
+def test_terminal_page_resyncs_history_after_stream_gap(tmp_path, monkeypatch):
+    """Events published while the SSE stream is down are never replayed by
+    the gateway, so the page must repaint from the turn ledger on every
+    reconnect and on returning to a backgrounded tab."""
+    client = _authed_client(tmp_path, monkeypatch)
+
+    async def fake_gateway_json(path, *a, **kw):
+        if path == "/broker/minds":
+            return [{"id": "ada-id", "name": "ada"}]
+        return []
+
+    with patch("main._gateway_json", side_effect=fake_gateway_json):
+        response = client.get("/terminal")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "resyncFromHistory" in body
+    assert "needsResync" in body
+    assert "visibilitychange" in body
+
+
+def test_terminal_page_walks_to_successor_on_deleted_session(tmp_path, monkeypatch):
+    """A 404 from the gateway events endpoint means the session row is gone
+    (deleted outright, not just rotated) — the page must run the same
+    successor walk as session_closed instead of reconnecting forever."""
+    client = _authed_client(tmp_path, monkeypatch)
+
+    async def fake_gateway_json(path, *a, **kw):
+        if path == "/broker/minds":
+            return [{"id": "ada-id", "name": "ada"}]
+        return []
+
+    with patch("main._gateway_json", side_effect=fake_gateway_json):
+        response = client.get("/terminal")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "handleSessionGone" in body
+    assert "upstream_error: 404" in body


### PR DESCRIPTION
## Problem
Terminal replies travel only over the SSE events channel. The gateway keeps no observer history, and Cloudflare cuts idle SSE connections (~2min cycle observed) — any reply completing during a reconnect gap vanished. Session d5893112's completed reply was lost exactly this way.

## Fix
- Anti-buffering headers (`Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`) on `/api/console/{id}/stream`.
- `resyncFromHistory()`: repaints the feed from the turn ledger on every stream reconnect, on tab visibility return, and once more at the next `result` if a repaint landed mid-turn. Confirms sent-but-unconfirmed queued messages found in the ledger; repaints the rest as pending.
- `upstream_error: 404` from the events proxy now runs the same successor walk as `session_closed`, covering sessions deleted outright.

Pairs with danielstewart77/hive_nervous_system#9 (20s heartbeat on the gateway events stream).

## Verification
- Full suite: 81 passed (4 new tests).
- Live: authenticated SSE through the app shows heartbeat pings and the new headers; `/terminal` serves the new JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)