### PR TITLE
terminal: propagate tile geometry to the pty (resize channel)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -737,27 +737,31 @@ async def api_memory_rows(
     }
 
 
-def _gateway_ws_url(session_id: str) -> str:
+def _gateway_ws_url(session_id: str, cols: str = "80", rows: str = "24") -> str:
     ws_base = _gateway_base_url().rstrip("/").replace("https://", "wss://").replace("http://", "ws://")
-    return f"{ws_base}/sessions/{session_id}/attach"
+    query = urllib.parse.urlencode({"cols": cols, "rows": rows})
+    return f"{ws_base}/sessions/{session_id}/attach?{query}"
 
 
 async def _pump_terminal_ws(browser_ws: WebSocket, mind_ws) -> None:
-    """Bridge raw bytes between the browser's terminal WS and hive-comms' attach WS.
+    """Bridge the browser's terminal WS and hive-comms' attach WS.
 
-    Whichever side closes first ends the bridge — an attached pty and a
-    browser tab have no independent life of their own once either end is gone.
+    Frame types are load-bearing on the browser→mind leg: BINARY frames
+    are raw terminal bytes, TEXT frames are JSON control messages
+    (resize) — so TEXT is forwarded as TEXT (websockets sends str frames
+    as TEXT), never re-encoded into the byte stream. Whichever side
+    closes first ends the bridge — an attached pty and a browser tab
+    have no independent life of their own once either end is gone.
     """
     async def browser_to_mind() -> None:
         while True:
             msg = await browser_ws.receive()
             if msg.get("type") == "websocket.disconnect":
                 return
-            data = msg.get("bytes")
-            if data is None and msg.get("text") is not None:
-                data = msg["text"].encode()
-            if data:
-                await mind_ws.send(data)
+            if msg.get("bytes"):
+                await mind_ws.send(msg["bytes"])
+            elif msg.get("text"):
+                await mind_ws.send(msg["text"])
 
     async def mind_to_browser() -> None:
         async for data in mind_ws:
@@ -791,9 +795,11 @@ async def ws_terminal_attach(websocket: WebSocket, session_id: str):
         return
 
     await websocket.accept()
+    cols = websocket.query_params.get("cols") or "80"
+    rows = websocket.query_params.get("rows") or "24"
     try:
         async with websockets.connect(
-            _gateway_ws_url(session_id),
+            _gateway_ws_url(session_id, cols=cols, rows=rows),
             additional_headers=_gateway_headers(),
         ) as mind_ws:
             await _pump_terminal_ws(websocket, mind_ws)

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -127,9 +127,10 @@
         return flattenContent(v);
     }
 
-    function wsUrl(sessionId) {
+    function wsUrl(sessionId, cols, rows) {
         const proto = location.protocol === "https:" ? "wss:" : "ws:";
-        return proto + "//" + location.host + "/api/terminal/attach/" + encodeURIComponent(sessionId);
+        return proto + "//" + location.host + "/api/terminal/attach/" + encodeURIComponent(sessionId) +
+            "?cols=" + encodeURIComponent(cols || 80) + "&rows=" + encodeURIComponent(rows || 24);
     }
 
     // ── one live session, rendered as an xterm tile ────────────────
@@ -376,13 +377,20 @@
                 try { dead.close(); } catch (err) { /* already closing */ }
             }
         }
+        // TEXT frames are the control channel (the pty end parses them as
+        // JSON); terminal bytes always travel as BINARY frames.
+        function sendResize() {
+            if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({type: "resize", cols: term.cols, rows: term.rows}));
+            }
+        }
         function attach() {
             closeSocket();
             term.reset();
             setAttachState("connecting…");
-            const socket = new WebSocket(wsUrl(sessionId));
+            const socket = new WebSocket(wsUrl(sessionId, term.cols, term.rows));
             socket.binaryType = "arraybuffer";
-            socket.onopen = () => setAttachState("attached");
+            socket.onopen = () => { setAttachState("attached"); sendResize(); };
             socket.onmessage = (ev) => {
                 term.write(ev.data instanceof ArrayBuffer ? new Uint8Array(ev.data) : ev.data);
             };
@@ -492,7 +500,9 @@
                 attach();
             },
             fit: function () {
+                const before = term.cols + "x" + term.rows;
                 try { fitAddon.fit(); } catch (e) {}
+                if (term.cols + "x" + term.rows !== before) sendResize();
             },
             focus: function () { focusedPanel = panel; term.focus(); },
             sendBytes: function (text) {

--- a/tests/test_console_routes.py
+++ b/tests/test_console_routes.py
@@ -503,6 +503,47 @@ def test_attach_ws_relays_browser_input_to_mind(tmp_path, monkeypatch):
             assert fake_ws.sent == [b"/help\n"]
 
 
+def test_attach_ws_forwards_resize_text_frames_as_text(tmp_path, monkeypatch):
+    """TEXT frames are the resize control channel; re-encoding them into the
+    byte stream would type JSON into the TUI instead of resizing the pty."""
+    client = _authed_client(tmp_path, monkeypatch)
+    fake_ws = _FakeMindWS(incoming=[])
+
+    def _fake_connect(url, **kwargs):
+        return fake_ws
+
+    resize = '{"type":"resize","cols":100,"rows":30}'
+    with patch("main.websockets.connect", _fake_connect):
+        with client.websocket_connect("/api/terminal/attach/sess-2") as ws:
+            ws.send_text(resize)
+            ws.send_bytes(b"ls\n")
+            import time
+            for _ in range(40):
+                if len(fake_ws.sent) >= 2:
+                    break
+                time.sleep(0.05)
+            assert fake_ws.sent == [resize, b"ls\n"]
+            assert isinstance(fake_ws.sent[0], str)
+
+
+def test_attach_ws_passes_tile_geometry_to_gateway(tmp_path, monkeypatch):
+    """cols/rows from the browser tile ride the attach URL so the pty spawns
+    at the tile's real geometry instead of a blind 80x24."""
+    client = _authed_client(tmp_path, monkeypatch)
+    fake_ws = _FakeMindWS(incoming=[b"ready"])
+
+    def _fake_connect(url, **kwargs):
+        _fake_connect.requested_url = url
+        return fake_ws
+
+    with patch("main.websockets.connect", _fake_connect):
+        with client.websocket_connect("/api/terminal/attach/sess-1?cols=132&rows=43") as ws:
+            ws.receive_bytes()
+
+    assert "cols=132" in _fake_connect.requested_url
+    assert "rows=43" in _fake_connect.requested_url
+
+
 def test_attach_ws_closes_1011_when_gateway_unreachable(tmp_path, monkeypatch):
     client = _authed_client(tmp_path, monkeypatch)
 


### PR DESCRIPTION
Tiles rendered garbled text because the pty never learned the browser
tile's size: the TUI painted for 80x24 while xterm.js showed something
else, and horizontal resizes never rewrapped. The attach WS now carries
cols/rows query params for spawn-time geometry, xterm sends
{"type":"resize"} TEXT control frames on every fit that changes
dimensions, and the proxy pump forwards TEXT frames as TEXT instead of
re-encoding them into the byte stream (which would have typed JSON into
the TUI).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
