### PR TITLE
terminal: server-side session labels (cross-device names + colors)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,7 @@ from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, Red
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+import auth
 from auth import (
     clear_session_cookie,
     get_current_user_from_request,
@@ -641,6 +642,68 @@ async def _create_gateway_session(mind_id: str) -> dict:
 async def api_minds(user: dict = Depends(require_auth)):
     del user
     return await _gateway_json("/broker/minds")
+
+
+def _labels_db() -> sqlite3.Connection:
+    """Terminal session labels (name + color) live next to the auth tables.
+
+    Server-side so they follow the user across devices — localStorage kept
+    them per-browser, which read as losing the session on the phone.
+    """
+    conn = auth._connect()
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS terminal_labels (
+               session_id TEXT PRIMARY KEY,
+               name TEXT NOT NULL DEFAULT '',
+               color TEXT NOT NULL DEFAULT '',
+               updated_at INTEGER NOT NULL
+           )"""
+    )
+    conn.commit()
+    return conn
+
+
+_LABEL_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{3,8}$")
+
+
+@app.get("/api/terminal/labels")
+async def api_terminal_labels(user: dict = Depends(require_auth)):
+    del user
+    conn = _labels_db()
+    try:
+        rows = conn.execute("SELECT session_id, name, color FROM terminal_labels").fetchall()
+    finally:
+        conn.close()
+    return {r["session_id"]: {"name": r["name"], "color": r["color"]} for r in rows}
+
+
+@app.put("/api/terminal/labels/{session_id}")
+async def api_terminal_label_put(
+    session_id: str, request: Request, user: dict = Depends(require_auth)
+):
+    del user
+    body = await request.json()
+    name = (body.get("name") or "").strip()[:40]
+    color = (body.get("color") or "").strip()
+    if color and not _LABEL_COLOR_RE.match(color):
+        raise HTTPException(status_code=400, detail="color must be a hex value")
+    conn = _labels_db()
+    try:
+        if not name and not color:
+            conn.execute("DELETE FROM terminal_labels WHERE session_id = ?", (session_id,))
+        else:
+            conn.execute(
+                """INSERT INTO terminal_labels (session_id, name, color, updated_at)
+                   VALUES (?, ?, ?, strftime('%s','now'))
+                   ON CONFLICT(session_id) DO UPDATE
+                   SET name = excluded.name, color = excluded.color,
+                       updated_at = excluded.updated_at""",
+                (session_id, name, color),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return {"ok": True, "session_id": session_id, "name": name, "color": color}
 
 
 _TABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -82,31 +82,62 @@
         try { return JSON.parse(localStorage.getItem("term-open") || "[]") || []; } catch (e) { return []; }
     }
 
-    // ── per-session labels (custom name + color), local to this browser ──
+    // ── per-session labels (custom name + color), server-backed ──────
+    // Stored via /api/terminal/labels so names and colors follow the user
+    // across devices; localStorage is only a warm-start cache (and the
+    // migration source for labels created before the server store).
     const LABEL_COLORS = ["#4ee8fc", "#4ee88a", "#c9a84c", "#e0724e", "#b06ee0", "#e05c8a", "#7e93a8"];
-    function loadLabels() {
+    let labelsCache = (function () {
         try { return JSON.parse(localStorage.getItem("term-labels") || "{}") || {}; } catch (e) { return {}; }
+    })();
+    function cacheLabelsLocally() {
+        try { localStorage.setItem("term-labels", JSON.stringify(labelsCache)); } catch (e) {}
     }
-    function saveLabels(map) {
-        try { localStorage.setItem("term-labels", JSON.stringify(map)); } catch (e) {}
+    function pushLabel(id, label) {
+        fetch("/api/terminal/labels/" + encodeURIComponent(id), {
+            method: "PUT", credentials: "same-origin",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({name: label.name || "", color: label.color || ""}),
+        }).catch(function () {});
+    }
+    async function syncLabelsFromServer() {
+        let server = null;
+        try {
+            const resp = await fetch("/api/terminal/labels", {credentials: "same-origin"});
+            if (resp.ok) server = await resp.json();
+        } catch (e) {}
+        if (!server || typeof server !== "object") return;
+        // One-time migration: labels this browser has that the server lacks.
+        Object.keys(labelsCache).forEach(function (id) {
+            if (!server[id]) pushLabel(id, labelsCache[id]);
+        });
+        labelsCache = Object.assign({}, labelsCache, server);
+        cacheLabelsLocally();
+        renderCards(lastRows);
+        openPanels.forEach(function (p) { p.refreshLabel(); });
     }
     function getLabel(id) {
         if (!id) return {};
-        const l = loadLabels()[id];
+        const l = labelsCache[id];
         return (l && typeof l === "object") ? l : {};
     }
     function setLabel(id, patch) {
         if (!id) return;
-        const map = loadLabels();
-        const cur = (map[id] && typeof map[id] === "object") ? map[id] : {};
+        const cur = (labelsCache[id] && typeof labelsCache[id] === "object") ? labelsCache[id] : {};
         const next = Object.assign({}, cur, patch);
-        if (!next.name && !next.color) delete map[id]; else map[id] = next;
-        saveLabels(map);
+        if (!next.name && !next.color) delete labelsCache[id]; else labelsCache[id] = next;
+        cacheLabelsLocally();
+        pushLabel(id, next);
     }
     function migrateLabel(oldId, newId) {
         if (!oldId || !newId || oldId === newId) return;
-        const map = loadLabels();
-        if (map[oldId]) { map[newId] = map[oldId]; delete map[oldId]; saveLabels(map); }
+        const label = labelsCache[oldId];
+        if (!label) return;
+        labelsCache[newId] = label;
+        delete labelsCache[oldId];
+        cacheLabelsLocally();
+        pushLabel(newId, label);
+        pushLabel(oldId, {});
     }
 
     // ── shared content helpers (assistant text out of console SSE) ──
@@ -513,6 +544,7 @@
                 if (term.cols + "x" + term.rows !== before) sendResize();
             },
             focus: function () { focusedPanel = panel; term.focus(); },
+            refreshLabel: applyLabel,
             sendBytes: function (text) {
                 if (ws && ws.readyState === WebSocket.OPEN) {
                     ws.send(new TextEncoder().encode(text));
@@ -770,6 +802,7 @@
     } catch (e) {}
 
     showView("list");
+    syncLabelsFromServer();
     refreshSessions().then(function (rows) {
         // Desktop: reopen the previously-open grid (or fall back to the most
         // recent active session so the stage isn't empty). Mobile lands on

--- a/tests/test_terminal_labels.py
+++ b/tests/test_terminal_labels.py
@@ -1,0 +1,83 @@
+"""Server-side terminal session labels (name + color).
+
+Labels were localStorage-only, so a session renamed on the desktop showed
+up unnamed on the phone. They now live in the auth database and sync via
+/api/terminal/labels, with the browser cache as warm-start only.
+"""
+
+import os
+import sys
+
+from starlette.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import auth
+import main as main_mod
+
+
+def _authed_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("STB_DB_PATH", str(tmp_path / "stb.db"))
+    monkeypatch.setenv("STB_SECRET_KEY", "test-secret")
+    user = auth.create_user("daniel", "secret-pass", is_admin=True, replace=True)
+    client = TestClient(main_mod.app)
+    client.cookies.set(auth.SESSION_COOKIE_NAME, auth.create_session_token(user))
+    return client
+
+
+def test_labels_roundtrip(tmp_path, monkeypatch):
+    client = _authed_client(tmp_path, monkeypatch)
+
+    assert client.get("/api/terminal/labels").json() == {}
+
+    put = client.put(
+        "/api/terminal/labels/sess-1", json={"name": "deploy bot", "color": "#4ee8fc"}
+    )
+    assert put.status_code == 200
+
+    labels = client.get("/api/terminal/labels").json()
+    assert labels == {"sess-1": {"name": "deploy bot", "color": "#4ee8fc"}}
+
+
+def test_label_update_overwrites(tmp_path, monkeypatch):
+    client = _authed_client(tmp_path, monkeypatch)
+    client.put("/api/terminal/labels/sess-1", json={"name": "old", "color": "#c9a84c"})
+    client.put("/api/terminal/labels/sess-1", json={"name": "new", "color": ""})
+
+    labels = client.get("/api/terminal/labels").json()
+    assert labels["sess-1"] == {"name": "new", "color": ""}
+
+
+def test_empty_label_deletes_row(tmp_path, monkeypatch):
+    client = _authed_client(tmp_path, monkeypatch)
+    client.put("/api/terminal/labels/sess-1", json={"name": "x", "color": ""})
+    client.put("/api/terminal/labels/sess-1", json={"name": "", "color": ""})
+
+    assert client.get("/api/terminal/labels").json() == {}
+
+
+def test_rejects_non_hex_color(tmp_path, monkeypatch):
+    client = _authed_client(tmp_path, monkeypatch)
+    resp = client.put(
+        "/api/terminal/labels/sess-1",
+        json={"name": "x", "color": "javascript:alert(1)"},
+    )
+    assert resp.status_code == 400
+
+
+def test_labels_require_auth(tmp_path, monkeypatch):
+    monkeypatch.setenv("STB_DB_PATH", str(tmp_path / "stb.db"))
+    monkeypatch.setenv("STB_SECRET_KEY", "test-secret")
+    client = TestClient(main_mod.app)
+    assert client.get("/api/terminal/labels").status_code == 401
+    assert client.put("/api/terminal/labels/s", json={"name": "x"}).status_code == 401
+
+
+def test_terminal_page_wires_label_sync():
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+    assert "/api/terminal/labels" in body
+    assert "syncLabelsFromServer" in body


### PR DESCRIPTION
Labels lived in localStorage, so a session named and colored on the
desktop showed up anonymous on the phone. They now persist in the auth
database via GET /api/terminal/labels and PUT
/api/terminal/labels/{session_id} (empty name+color deletes; colors
validated as hex). The page keeps localStorage as a warm-start cache,
pushes any local-only labels up on first sync (one-time migration),
and refreshes open tiles and the rail when server labels arrive.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
