### PR TITLE
terminal: route reattach by session lineage instead of guessing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -590,6 +590,10 @@ async def api_terminal_sessions(user: dict = Depends(require_auth)):
             "last_active": s.get("last_active"),
             "age": _relative_age(now, s.get("last_active")),
             "summary": (s.get("summary") or "").strip(),
+            # Lineage, so a tile whose session rotated can identify its
+            # actual replacement instead of adopting whichever sibling
+            # session happens to be live on the same mind.
+            "rotated_from": s.get("rotated_from") or "",
         })
     rows.sort(key=lambda r: -float(r.get("last_active") or 0))
     return rows

--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -1,0 +1,59 @@
+/* Reattach routing for the web terminal.
+ *
+ * When a terminal tile's socket drops it has to decide what to reconnect
+ * to. Getting this wrong is not cosmetic: the previous rule was "any live
+ * session on the same mind", so with two tiles open the reconnecting one
+ * adopted its neighbour's conversation, took its neighbour's name and
+ * colour with it, and left the neighbour blank.
+ *
+ * The rules, in order:
+ *   1. The same session, if it is still live. The pty now outlives the
+ *      socket, so this is the ordinary case — a dropped connection, not a
+ *      dead conversation.
+ *   2. The session that rotation created to replace it, identified by
+ *      recorded lineage (rotated_from) and not by proximity.
+ *   3. Nothing. Waiting beats stealing.
+ *
+ * A session another tile already has open is never a candidate.
+ */
+(function (root) {
+    "use strict";
+
+    var ACTIVE_STATUSES = ["running", "idle"];
+
+    function isActive(row) {
+        return ACTIVE_STATUSES.indexOf(String(row && row.status || "").toLowerCase()) !== -1;
+    }
+
+    /**
+     * @param {Array} rows      session rows from /api/terminal/sessions
+     * @param {Object} opts     {deadId, openIds}
+     * @returns {{action: "retry"|"successor"|"wait", session?: Object}}
+     */
+    function pickReattachTarget(rows, opts) {
+        var list = Array.isArray(rows) ? rows : [];
+        var deadId = (opts && opts.deadId) || "";
+        var openIds = (opts && opts.openIds) || [];
+        if (!deadId) return {action: "wait"};
+
+        var i;
+        for (i = 0; i < list.length; i++) {
+            if (list[i] && list[i].id === deadId && isActive(list[i])) {
+                return {action: "retry"};
+            }
+        }
+        for (i = 0; i < list.length; i++) {
+            var row = list[i];
+            if (!row || row.id === deadId) continue;
+            if (!row.rotated_from || row.rotated_from !== deadId) continue;
+            if (!isActive(row)) continue;
+            // Another tile is already driving this one — adopting it would
+            // put two terminals on one conversation.
+            if (openIds.indexOf(row.id) !== -1) continue;
+            return {action: "successor", session: row};
+        }
+        return {action: "wait"};
+    }
+
+    root.TerminalRouting = {pickReattachTarget: pickReattachTarget, isActive: isActive};
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -42,6 +42,7 @@
 
 <script src="{{ request.url_for('static', path='vendor/xterm/xterm.js') }}"></script>
 <script src="{{ request.url_for('static', path='vendor/xterm/addon-fit.js') }}"></script>
+<script src="{{ request.url_for('static', path='terminal-routing.js') }}"></script>
 <script>
 (function () {
     "use strict";
@@ -65,7 +66,6 @@
     const railExpandBtn = document.getElementById("term-rail-expand");
     const toolbar = document.getElementById("term-mobile-toolbar");
 
-    const ACTIVE_STATUSES = new Set(["running", "idle"]);
     const REATTACH_WINDOW_MS = 30000;
     const isWide = () => window.matchMedia("(min-width: 860px)").matches;
 
@@ -436,6 +436,13 @@
                     refreshSessions();
                     return;
                 }
+                // 1012 = another tab/tile attached to this same session and
+                // took the keyboard. Reconnecting would start a tug-of-war,
+                // so this tile stands down instead.
+                if (ev && ev.code === 1012) {
+                    setAttachState("open in another window");
+                    return;
+                }
                 // Rotation kills the pty out from under the tile; hunt for
                 // the successor session instead of sitting dead forever.
                 setAttachState("disconnected");
@@ -470,11 +477,12 @@
                 const resp = await fetch("/api/terminal/sessions", {credentials: "same-origin"});
                 if (resp.ok) {
                     const rows = await resp.json();
-                    const successor = (rows || []).find(function (r) {
-                        return r.mind_id === mindId && r.id !== deadId &&
-                            ACTIVE_STATUSES.has((r.status || "").toLowerCase());
+                    const target = TerminalRouting.pickReattachTarget(rows, {
+                        deadId: deadId,
+                        openIds: Array.from(openPanels.keys()),
                     });
-                    if (successor) { attachSuccessor(successor); return; }
+                    if (target.action === "retry") { cancelReattachLoop(); attach(); return; }
+                    if (target.action === "successor") { attachSuccessor(target.session); return; }
                 }
             } catch (err) {}
             if (Date.now() - reattachStartedAt >= REATTACH_WINDOW_MS) {
@@ -629,7 +637,7 @@
     });
 
     // ── session list rendering (flat rows grouped by mind) ────────
-    function isActiveStatus(status) { return ACTIVE_STATUSES.has((status || "").toLowerCase()); }
+    function isActiveStatus(status) { return TerminalRouting.isActive({status: status}); }
     function statusDotClass(status) {
         const s = (status || "").toLowerCase();
         if (s === "running") return "is-running";

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -1,0 +1,116 @@
+/* Reattach routing rules for the web terminal.
+ *
+ * Run by tests/test_terminal_routing.py. Every case here is a shape that
+ * actually broke: tiles adopting each other's conversations, labels
+ * following the wrong session, and a live session declared dead because
+ * its socket blinked.
+ */
+import assert from "node:assert/strict";
+import {readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// The module is a browser script, not an ES module — evaluate it the way a
+// <script> tag would, against globalThis.
+new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
+const {pickReattachTarget, isActive} = globalThis.TerminalRouting;
+
+const tests = {
+    "a live session is retried, not replaced"() {
+        const rows = [{id: "a", status: "running"}];
+        assert.deepEqual(pickReattachTarget(rows, {deadId: "a", openIds: ["a"]}), {action: "retry"});
+    },
+
+    "an idle session still counts as live"() {
+        const rows = [{id: "a", status: "idle"}];
+        assert.equal(pickReattachTarget(rows, {deadId: "a", openIds: []}).action, "retry");
+    },
+
+    "a rotation successor is adopted by lineage"() {
+        const rows = [
+            {id: "a", status: "closed"},
+            {id: "b", status: "running", rotated_from: "a"},
+        ];
+        const target = pickReattachTarget(rows, {deadId: "a", openIds: ["a"]});
+        assert.equal(target.action, "successor");
+        assert.equal(target.session.id, "b");
+    },
+
+    "a sibling session on the same mind is NEVER adopted"() {
+        // The exact bug: two terminals open, one drops, and it grabs the
+        // other one's conversation along with its name and colour.
+        const rows = [
+            {id: "hex", status: "closed", mind_id: "skippy"},
+            {id: "ada-proxy", status: "running", mind_id: "skippy"},
+        ];
+        assert.deepEqual(
+            pickReattachTarget(rows, {deadId: "hex", openIds: ["hex", "ada-proxy"]}),
+            {action: "wait"},
+        );
+    },
+
+    "a successor already open in another tile is left alone"() {
+        const rows = [
+            {id: "a", status: "closed"},
+            {id: "b", status: "running", rotated_from: "a"},
+        ];
+        assert.equal(
+            pickReattachTarget(rows, {deadId: "a", openIds: ["a", "b"]}).action,
+            "wait",
+        );
+    },
+
+    "a closed successor is not adopted"() {
+        const rows = [
+            {id: "a", status: "closed"},
+            {id: "b", status: "closed", rotated_from: "a"},
+        ];
+        assert.equal(pickReattachTarget(rows, {deadId: "a", openIds: []}).action, "wait");
+    },
+
+    "lineage pointing at a different session does not match"() {
+        const rows = [
+            {id: "a", status: "closed"},
+            {id: "b", status: "running", rotated_from: "someone-else"},
+        ];
+        assert.equal(pickReattachTarget(rows, {deadId: "a", openIds: []}).action, "wait");
+    },
+
+    "retry wins over an equally valid successor"() {
+        // If the original is still alive, the conversation never moved.
+        const rows = [
+            {id: "a", status: "running"},
+            {id: "b", status: "running", rotated_from: "a"},
+        ];
+        assert.equal(pickReattachTarget(rows, {deadId: "a", openIds: []}).action, "retry");
+    },
+
+    "empty and malformed inputs wait rather than guess"() {
+        assert.equal(pickReattachTarget([], {deadId: "a", openIds: []}).action, "wait");
+        assert.equal(pickReattachTarget(null, {deadId: "a", openIds: []}).action, "wait");
+        assert.equal(pickReattachTarget([{id: "a", status: "running"}], {}).action, "wait");
+        assert.equal(pickReattachTarget([null, undefined], {deadId: "a"}).action, "wait");
+    },
+
+    "isActive classifies the statuses the rail renders"() {
+        assert.equal(isActive({status: "RUNNING"}), true);
+        assert.equal(isActive({status: "idle"}), true);
+        assert.equal(isActive({status: "closed"}), false);
+        assert.equal(isActive({}), false);
+        assert.equal(isActive(null), false);
+    },
+};
+
+let failed = 0;
+for (const [name, fn] of Object.entries(tests)) {
+    try {
+        fn();
+        console.log("ok - " + name);
+    } catch (err) {
+        failed++;
+        console.error("FAIL - " + name + "\n  " + err.message);
+    }
+}
+console.log(`\n${Object.keys(tests).length - failed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -1,0 +1,96 @@
+"""Web-terminal reattach routing.
+
+Two halves of one fix: the server has to hand the browser session lineage
+(``rotated_from``), and the browser has to route on it. Without lineage a
+reconnecting terminal tile guessed at "some live session on this mind" and
+adopted whichever sibling it found — crossing two conversations and
+migrating one tile's name and colour onto the other's session.
+
+The browser half lives in ``src/static/terminal-routing.js`` and is
+exercised by ``tests/js/terminal_routing_test.mjs``, run here so one
+``pytest`` covers both sides.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+from starlette.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import auth
+import main as main_mod
+
+
+def _authed_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("STB_DB_PATH", str(tmp_path / "stb.db"))
+    monkeypatch.setenv("STB_SECRET_KEY", "test-secret")
+    user = auth.create_user("daniel", "secret-pass", is_admin=True, replace=True)
+    client = TestClient(main_mod.app)
+    client.cookies.set(auth.SESSION_COOKIE_NAME, auth.create_session_token(user))
+    return client
+
+
+def _fake_gateway(monkeypatch, sessions):
+    async def _gateway_json(path, *a, **kw):
+        if path == "/broker/minds":
+            return [{"id": "mind-uuid", "name": "skippy"}]
+        if path == "/sessions":
+            return sessions
+        return []
+
+    monkeypatch.setattr(main_mod, "_gateway_json", _gateway_json)
+
+
+def test_session_list_carries_lineage(tmp_path, monkeypatch):
+    client = _authed_client(tmp_path, monkeypatch)
+    _fake_gateway(monkeypatch, [
+        {"id": "old", "mind_id": "mind-uuid", "status": "closed", "last_active": 1},
+        {"id": "new", "mind_id": "mind-uuid", "status": "running",
+         "last_active": 2, "rotated_from": "old"},
+    ])
+
+    rows = client.get("/api/terminal/sessions").json()
+
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["new"]["rotated_from"] == "old"
+    assert by_id["old"]["rotated_from"] == ""
+
+
+def test_lineage_absent_is_empty_not_missing(tmp_path, monkeypatch):
+    """Older gateway rows have no such column; the key must still exist so
+    the browser's comparison is against "" rather than undefined."""
+    client = _authed_client(tmp_path, monkeypatch)
+    _fake_gateway(monkeypatch, [
+        {"id": "solo", "mind_id": "mind-uuid", "status": "running", "last_active": 1},
+    ])
+
+    rows = client.get("/api/terminal/sessions").json()
+
+    assert rows[0]["rotated_from"] == ""
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_browser_reattach_routing_rules():
+    script = os.path.join(os.path.dirname(__file__), "js", "terminal_routing_test.mjs")
+    result = subprocess.run(
+        [shutil.which("node"), script], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_template_uses_the_routing_module():
+    """Guard against the inline guess creeping back into the template."""
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+
+    assert "TerminalRouting.pickReattachTarget" in body
+    assert "terminal-routing.js" in body
+    # The old heuristic: any live session belonging to the same mind.
+    assert "r.mind_id === mindId" not in body


### PR DESCRIPTION
When a terminal tile's socket dropped it hunted for a replacement using `any live session on the same mind`. With two tiles open that found the neighbour: the reconnecting tile adopted a conversation it never owned, `migrateLabel` moved its name and colour onto the neighbour's session, and the neighbour's tile went blank. Renaming one tile and then watching the other tile's text appear under that name was this, not a display bug.

The rules now live in `src/static/terminal-routing.js::pickReattachTarget`, out of the template and under test: retry the same session while it is still live (the pty outlives the socket now, so a dropped connection is the ordinary case), otherwise adopt only the session whose `rotated_from` names it, and never adopt one another tile already has open. `/api/terminal/sessions` passes the lineage through. Close code 1012 (this session was opened elsewhere) stands the tile down instead of starting a tug-of-war.

88 Python tests plus 10 JS cases pass; the JS runs under `pytest` via node.