### PR TITLE
terminal: stop reconnecting to a mind that has no terminal

### DIFF
--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -55,5 +55,25 @@
         return {action: "wait"};
     }
 
-    root.TerminalRouting = {pickReattachTarget: pickReattachTarget, isActive: isActive};
+    /**
+     * Delay before retrying an attach to the same session, in ms.
+     *
+     * The first retry is quick — the common case is a dropped socket over
+     * a live pty, and waiting there is felt. Repeated failures mean the
+     * attach itself is being refused, so the interval grows and caps
+     * rather than spinning at the speed of the round trip.
+     *
+     * @param {number} attempt  1 for the first retry after a live socket
+     * @returns {number} ms to wait
+     */
+    function retryDelayMs(attempt) {
+        var n = Math.max(1, Math.floor(attempt) || 1);
+        return Math.min(500 * Math.pow(2, n - 1), 8000);
+    }
+
+    root.TerminalRouting = {
+        pickReattachTarget: pickReattachTarget,
+        isActive: isActive,
+        retryDelayMs: retryDelayMs,
+    };
 })(typeof globalThis !== "undefined" ? globalThis : this);

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -224,6 +224,7 @@
         let deliberateClose = false;
         let reattachTimer = null;
         let reattachStartedAt = 0;
+        let reattachAttempts = 0;   // consecutive failed attaches; reset on a live socket
 
         function setInfo() {
             const label = getLabel(sessionId);
@@ -421,7 +422,7 @@
             setAttachState("connecting…");
             const socket = new WebSocket(wsUrl(sessionId, term.cols, term.rows));
             socket.binaryType = "arraybuffer";
-            socket.onopen = () => { setAttachState("attached"); sendResize(); };
+            socket.onopen = () => { reattachAttempts = 0; setAttachState("attached"); sendResize(); };
             socket.onmessage = (ev) => {
                 term.write(ev.data instanceof ArrayBuffer ? new Uint8Array(ev.data) : ev.data);
             };
@@ -441,6 +442,13 @@
                 // so this tile stands down instead.
                 if (ev && ev.code === 1012) {
                     setAttachState("open in another window");
+                    return;
+                }
+                // 4415 = the mind is reachable but has no pty route (its
+                // image predates the terminal work). Retrying just spins,
+                // so say what's wrong and stop.
+                if (ev && ev.code === 4415) {
+                    setAttachState("no terminal on this mind");
                     return;
                 }
                 // Rotation kills the pty out from under the tile; hunt for
@@ -481,7 +489,18 @@
                         deadId: deadId,
                         openIds: Array.from(openPanels.keys()),
                     });
-                    if (target.action === "retry") { cancelReattachLoop(); attach(); return; }
+                    if (target.action === "retry") {
+                        // Back off between tries. An attach that fails as
+                        // fast as it opens (a mind that refuses the
+                        // handshake) would otherwise loop several times a
+                        // second and hammer the gateway.
+                        cancelReattachLoop();
+                        reattachAttempts += 1;
+                        const wait = TerminalRouting.retryDelayMs(reattachAttempts);
+                        setAttachState("reconnecting…");
+                        reattachTimer = setTimeout(attach, wait);
+                        return;
+                    }
                     if (target.action === "successor") { attachSuccessor(target.session); return; }
                 }
             } catch (err) {}

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -14,7 +14,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 // The module is a browser script, not an ES module — evaluate it the way a
 // <script> tag would, against globalThis.
 new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
-const {pickReattachTarget, isActive} = globalThis.TerminalRouting;
+const {pickReattachTarget, isActive, retryDelayMs} = globalThis.TerminalRouting;
 
 const tests = {
     "a live session is retried, not replaced"() {
@@ -91,6 +91,18 @@ const tests = {
         assert.equal(pickReattachTarget(null, {deadId: "a", openIds: []}).action, "wait");
         assert.equal(pickReattachTarget([{id: "a", status: "running"}], {}).action, "wait");
         assert.equal(pickReattachTarget([null, undefined], {deadId: "a"}).action, "wait");
+    },
+
+    "retries back off and cap instead of spinning"() {
+        assert.equal(retryDelayMs(1), 500);
+        assert.equal(retryDelayMs(2), 1000);
+        assert.equal(retryDelayMs(3), 2000);
+        // A mind that refuses every handshake must settle at the cap, not
+        // keep reconnecting several times a second.
+        assert.equal(retryDelayMs(20), 8000);
+        // Garbage in still yields a real wait.
+        assert.equal(retryDelayMs(0), 500);
+        assert.equal(retryDelayMs(undefined), 500);
     },
 
     "isActive classifies the statuses the rail renders"() {

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -94,3 +94,21 @@ def test_template_uses_the_routing_module():
     assert "terminal-routing.js" in body
     # The old heuristic: any live session belonging to the same mind.
     assert "r.mind_id === mindId" not in body
+
+
+def test_template_stops_retrying_a_mind_without_a_terminal():
+    """A mind whose image predates the pty route refuses the handshake, and
+    the gateway reports that as 4415. Treating it like a dropped socket span
+    the tile between connecting and reattaching several times a second."""
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+
+    assert "4415" in body
+    assert "no terminal on this mind" in body
+    # Retries to the same session go through the backoff, never straight
+    # back into attach().
+    assert "TerminalRouting.retryDelayMs" in body
+    assert "cancelReattachLoop(); attach(); return;" not in body


### PR DESCRIPTION
Browser half of hive_nervous_system#20.

A tile opened on a Hex session flapped between `connecting…` and `reattaching…` several times a second and rendered nothing. The gateway now reports 'mind has no pty route' as close code 4415, which the tile treats as terminal — it says `no terminal on this mind` and stands down.

Separately, the same-session retry path called `attach()` with no delay, so any attach that failed as fast as it opened looped at the speed of the round trip. Retries now back off from 500ms to a cap of 8s and reset once a socket actually opens.