### PR TITLE
terminal: recover mobile IME text dropped when Enter fires mid-composition

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1108,6 +1108,17 @@ body:has(.terminal-page) .content-wrapper > .terminal-box { display: none; }
 }
 .term-xterm .xterm { height: 100%; }
 
+/* xterm's own composition-view (the floating IME preview bubble, used
+   heavily by mobile soft keyboards) ships with white-space: nowrap and no
+   width cap -- on a narrow phone it runs off the right edge instead of
+   wrapping. Override with higher specificity than xterm.css's
+   .xterm .composition-view since load order alone can't be relied on. */
+.term-panel .xterm .composition-view {
+    max-width: calc(100% - 1rem);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 /* ── new-session mind picker ──────────────────────────── */
 .term-new-menu {
     display: flex;

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -464,6 +464,26 @@
                 ws.send(new TextEncoder().encode(text));
             }
         });
+        // Mobile virtual keyboards (Gboard, iOS predictive text) route typed
+        // words through an IME composition that isn't closed before Enter
+        // fires; xterm.js then discards the still-open composition instead
+        // of sending it (CompositionHelper.keydown -> finalizeComposition
+        // with commit=false), so the whole line silently vanishes and only
+        // a bare return reaches the pty. Forward whatever's still buffered
+        // in the helper textarea ourselves, ahead of xterm's own handler --
+        // a capture-phase listener on this ancestor runs before any
+        // listener on the textarea itself, composing or not -- then let
+        // Enter continue through the normal path.
+        xtermEl.addEventListener("keydown", function (e) {
+            if (e.key !== "Enter" && e.keyCode !== 13) return;
+            const helperTa = xtermEl.querySelector(".xterm-helper-textarea");
+            if (helperTa && helperTa.value) {
+                if (ws && ws.readyState === WebSocket.OPEN) {
+                    ws.send(new TextEncoder().encode(helperTa.value));
+                }
+                helperTa.value = "";
+            }
+        }, true);
         term.textarea && term.textarea.addEventListener("focus", function () { focusedPanel = panel; });
         el.addEventListener("mousedown", function () { focusedPanel = panel; });
 


### PR DESCRIPTION
## Summary
- xterm.js drops still-open IME composition text when Enter fires before compositionend (the pattern mobile soft keyboards use), so typed lines vanish on mobile and only a bare return reaches the pty.
- Forward the helper textarea's buffered value ourselves via a capture-phase keydown listener on an ancestor of the textarea, ahead of xterm's own handler, then let Enter proceed normally.
- Widen xterm's `.composition-view` preview bubble so in-progress mobile IME text wraps instead of running off the screen edge (it ships with `white-space: nowrap` and no max-width).

## Verification
Scripted a Playwright repro against the actual vendored `xterm.js`, replaying the exact CompositionEvent/InputEvent/KeyboardEvent sequence a mobile keyboard sends:
- Before fix: composing "git status" then Enter -> only `"\r"` reached `onData`, the text was lost.
- After fix: same sequence -> `"git status"` then `"\r"`.
- Plain physical-keyboard typing (no composition) -> unaffected, no duplication.

## Test plan
- [ ] Merge, deploy, confirm on an actual phone: type a multi-word command in the web terminal and hit Enter, confirm it runs and long in-progress text wraps instead of overflowing.