### PR TITLE
terminal: refit on container resize, not just window resize

### DIFF
--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -219,6 +219,22 @@
         const fitAddon = new window.FitAddon.FitAddon();
         term.loadAddon(fitAddon);
 
+        // window's "resize" event alone misses layout changes that don't
+        // resize the window itself -- a foldable unfolding, an on-screen
+        // keyboard opening, or this tile's own container changing shape
+        // when the rail collapses. Watch the tile's actual box instead.
+        let fitRaf = null;
+        function scheduleFit() {
+            if (fitRaf) return;
+            fitRaf = requestAnimationFrame(function () { fitRaf = null; doFit(); });
+        }
+        const resizeObserver = new ResizeObserver(scheduleFit);
+        function doFit() {
+            const before = term.cols + "x" + term.rows;
+            try { fitAddon.fit(); } catch (e) {}
+            if (term.cols + "x" + term.rows !== before) sendResize();
+        }
+
         let ws = null;
         let destroyed = false;
         let deliberateClose = false;
@@ -582,14 +598,11 @@
             mount: function () {
                 term.open(xtermEl);
                 fitAddon.fit();
+                resizeObserver.observe(xtermEl);
                 applyLabel();
                 attach();
             },
-            fit: function () {
-                const before = term.cols + "x" + term.rows;
-                try { fitAddon.fit(); } catch (e) {}
-                if (term.cols + "x" + term.rows !== before) sendResize();
-            },
+            fit: doFit,
             focus: function () { focusedPanel = panel; term.focus(); },
             refreshLabel: applyLabel,
             sendBytes: function (text) {
@@ -599,6 +612,8 @@
             },
             destroy: function () {
                 destroyed = true;
+                resizeObserver.disconnect();
+                if (fitRaf) { cancelAnimationFrame(fitRaf); fitRaf = null; }
                 cancelReattachLoop();
                 closeSocket();
                 closeTtsStream();
@@ -670,10 +685,10 @@
     }
 
     function showView(name) { termApp.dataset.view = name; }
-
-    window.addEventListener("resize", function () {
-        openPanels.forEach(function (p) { p.fit(); });
-    });
+    // No window-level resize listener: each panel's own ResizeObserver
+    // (see createPanel) reacts to that panel's actual box changing, which
+    // covers every case a window resize would have (and catches layout
+    // changes a window resize event doesn't reliably fire for).
 
     // ── session list rendering (flat rows grouped by mind) ────────
     function isActiveStatus(status) { return TerminalRouting.isActive({status: status}); }

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -148,3 +148,24 @@ def test_composition_view_wraps_on_mobile():
 
     assert ".composition-view" in body
     assert "pre-wrap" in body
+
+
+def test_terminal_refits_on_container_resize_not_just_window_resize():
+    """A window "resize" event alone misses layout changes that don't
+    resize the window itself -- a foldable unfolding, an on-screen keyboard
+    opening. Each panel must watch its own tile's box via ResizeObserver so
+    xterm's cols/rows actually grow when the tile does, instead of staying
+    pinned to whatever size it was at mount."""
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+
+    assert "new ResizeObserver(scheduleFit)" in body
+    assert "resizeObserver.observe(xtermEl)" in body
+    assert "resizeObserver.disconnect()" in body
+    # The old global-only trigger must be gone, not just supplemented --
+    # leaving it would be redundant dead weight now that each panel fits
+    # itself.
+    assert 'window.addEventListener("resize"' not in body


### PR DESCRIPTION
## Summary
- xterm's cols/rows only ever recalculated on a window "resize" event, which mobile browsers don't reliably fire for every layout change (foldable unfolding, on-screen keyboard, rail toggle) -- so the terminal kept wrapping at its old width even after its tile visibly grew.
- Each panel now watches its own `.term-xterm` box with a `ResizeObserver` and refits there; the old global window-resize listener is removed as redundant, not kept alongside it.

## Verification
Scripted against the actual vendored xterm.js: simulated a fold-unfold (viewport 380px -> 780px, no user interaction) -- cols grew 40 -> 85. Full suite (91 tests) passes, plus a new guard test.

## Test plan
- [ ] Merge, confirm on the fold phone: unfold mid-session, terminal should widen to fill the new screen width without needing to reopen the tile.