### PR TITLE
terminal: add redundant refit signals for foldables ResizeObserver misses

### DIFF
--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -685,10 +685,29 @@
     }
 
     function showView(name) { termApp.dataset.view = name; }
-    // No window-level resize listener: each panel's own ResizeObserver
-    // (see createPanel) reacts to that panel's actual box changing, which
-    // covers every case a window resize would have (and catches layout
-    // changes a window resize event doesn't reliably fire for).
+
+    // Each panel's own ResizeObserver (see createPanel) is the primary
+    // refit trigger, but a foldable unfolding is reported (not reproduced
+    // here in a headless Chromium run) to sometimes not resize a tile's
+    // box at all on some mobile browsers even though the physical screen
+    // -- and therefore the CSS viewport -- changed shape. visualViewport
+    // and orientationchange are independent browser signals for exactly
+    // that: a shape change that isn't a plain window resize. Redundant
+    // with the observer in a well-behaved browser; the point is not
+    // depending on any single one of the three firing.
+    function refitAllPanels() {
+        openPanels.forEach(function (p) { p.fit(); });
+    }
+    if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", refitAllPanels);
+    }
+    window.addEventListener("orientationchange", refitAllPanels);
+    // Belt and suspenders: if none of the three signals above fire on a
+    // given browser, this puts a hard ceiling of a couple seconds on how
+    // long a tile can stay mis-sized rather than staying wrong forever.
+    // fit() is cheap (a character-metric measurement plus an int compare)
+    // and only sends a resize frame when the size actually changed.
+    setInterval(refitAllPanels, 2000);
 
     // ── session list rendering (flat rows grouped by mind) ────────
     function isActiveStatus(status) { return TerminalRouting.isActive({status: status}); }

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -169,3 +169,24 @@ def test_terminal_refits_on_container_resize_not_just_window_resize():
     # leaving it would be redundant dead weight now that each panel fits
     # itself.
     assert 'window.addEventListener("resize"' not in body
+
+
+def test_terminal_has_redundant_refit_signals_for_foldables():
+    """ResizeObserver alone was verified (in a headless Chromium run
+    against the real production page, both mount-then-widen and
+    already-wide-then-mount) to refit correctly, but a foldable unfolding
+    is reported to still leave the terminal at a stale narrower width on
+    some real mobile browser that a Chromium run doesn't reproduce. Since
+    the failing signal can't be pinned down without the device, refitting
+    must not depend on any single browser event: visualViewport resize,
+    orientationchange, and a periodic self-check are independent
+    fallbacks alongside the per-panel ResizeObserver."""
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+
+    assert "window.visualViewport.addEventListener(\"resize\"" in body
+    assert 'window.addEventListener("orientationchange"' in body
+    assert "setInterval(refitAllPanels" in body


### PR DESCRIPTION
## Summary
- The per-panel ResizeObserver (previous PR) was verified correct against the real running app in a headless Chromium run, but the reported symptom persists on the real foldable device even after a refresh.
- Can't pin down the exact failing signal without the device -- likely an OEM Chromium fork (Samsung Internet) foldable-shape-change quirk.
- Added visualViewport resize, orientationchange, and a 2s self-check poll as independent fallbacks alongside ResizeObserver, so no single event type is a single point of failure.

## Verification
Full suite (93 tests) passes. Re-ran the existing real-app-via-headless-browser checks (fresh mount at wide viewport, mount-narrow-then-widen) after adding the new listeners -- no page errors, both still correct.

## Test plan
- [ ] Merge, confirm on the fold phone: unfold, terminal should now regrow within ~2s worst case even if the immediate resize signal is missed.