### PR TITLE
terminal: version-stamp every first-party static asset

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -253,16 +253,26 @@ def _render_hive_init_home(request: Request) -> HTMLResponse:
     return HTMLResponse(body)
 
 
+def _asset_versions() -> dict[str, int]:
+    """Cache-busting stamp for every first-party static file.
+
+    Enumerated rather than enumerated-by-hand: a hardcoded list silently
+    stops covering the next asset someone adds, which is how a stale
+    terminal-routing.js once outlived the terminal.html that called into
+    it. Only the top level of static/ — vendor/ is pinned third-party and
+    images are content-addressed by name.
+    """
+    static_dir = BASE_DIR / "static"
+    return {
+        path.name: int(path.stat().st_mtime_ns)
+        for path in static_dir.iterdir()
+        if path.is_file()
+    }
+
+
 def _render_template(request: Request, template_name: str, **context) -> HTMLResponse:
     context.setdefault("current_user", get_current_user_from_request(request))
-    static_dir = BASE_DIR / "static"
-    context.setdefault(
-        "asset_versions",
-        {
-            "style.css": int((static_dir / "style.css").stat().st_mtime_ns),
-            "scripts.js": int((static_dir / "scripts.js").stat().st_mtime_ns),
-        },
-    )
+    context.setdefault("asset_versions", _asset_versions())
     context["request"] = request
     return templates.TemplateResponse(request, template_name, context)
 

--- a/src/templates/pr.html
+++ b/src/templates/pr.html
@@ -1,6 +1,5 @@
 {% extends "layout.html" %}
 {% block content %}
-<link rel="stylesheet" href="{{ request.url_for('static', path='style.css') }}">
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 <script>
   mermaid.initialize({ startOnLoad: false, theme: 'dark' });

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -45,7 +45,7 @@
 
 <script src="{{ request.url_for('static', path='vendor/xterm/xterm.js') }}"></script>
 <script src="{{ request.url_for('static', path='vendor/xterm/addon-fit.js') }}"></script>
-<script src="{{ request.url_for('static', path='terminal-routing.js') }}"></script>
+<script src="{{ request.url_for('static', path='terminal-routing.js') }}?v={{ asset_versions['terminal-routing.js'] }}"></script>
 <script>
 (function () {
     "use strict";

--- a/tests/test_asset_versions.py
+++ b/tests/test_asset_versions.py
@@ -1,0 +1,84 @@
+"""First-party static assets must be served cache-busted.
+
+A stale `terminal-routing.js` cached against a freshly-rendered
+terminal.html is what blanked the session rail: the template called
+`TerminalRouting.contrastText`, the browser's cached copy predated that
+export, and the resulting TypeError aborted `renderCards` mid-loop so the
+page showed "No active sessions" with live sessions on the server.
+"""
+
+import os
+import re
+import sys
+
+import pytest
+from starlette.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import auth
+import main as main_mod
+
+TEMPLATE_DIR = main_mod.BASE_DIR / "templates"
+STATIC_DIR = main_mod.BASE_DIR / "static"
+
+# url_for('static', path='<name>') with whatever follows the closing brace,
+# so we can tell a stamped reference from a bare one.
+STATIC_REF = re.compile(
+    r"""url_for\(\s*['"]static['"]\s*,\s*path=['"](?P<path>[^'"]+)['"]\s*\)\s*\}\}(?P<suffix>[^"']*)"""
+)
+
+
+def _authed_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("STB_DB_PATH", str(tmp_path / "stb.db"))
+    monkeypatch.setenv("STB_SECRET_KEY", "test-secret")
+    user = auth.create_user("daniel", "secret-pass", is_admin=True, replace=True)
+    client = TestClient(main_mod.app)
+    client.cookies.set(auth.SESSION_COOKIE_NAME, auth.create_session_token(user))
+    return client
+
+
+def test_asset_versions_covers_every_first_party_static_file():
+    versions = main_mod._asset_versions()
+    on_disk = {p.name for p in STATIC_DIR.iterdir() if p.is_file()}
+    assert on_disk, "no first-party static files found — wrong BASE_DIR?"
+    assert set(versions) == on_disk
+    assert all(isinstance(v, int) and v > 0 for v in versions.values())
+
+
+def test_asset_versions_tracks_file_mtime(tmp_path, monkeypatch):
+    before = main_mod._asset_versions()["terminal-routing.js"]
+    target = STATIC_DIR / "terminal-routing.js"
+    stat = target.stat()
+    try:
+        os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+        assert main_mod._asset_versions()["terminal-routing.js"] != before
+    finally:
+        os.utime(target, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+
+
+@pytest.mark.parametrize(
+    "template", sorted(p.name for p in TEMPLATE_DIR.glob("*.html"))
+)
+def test_mutable_static_references_are_version_stamped(template):
+    """Every reference to a changeable first-party asset carries ?v=.
+
+    vendor/ is pinned third-party and images are effectively immutable, so
+    only top-level static files are required to be stamped.
+    """
+    source = (TEMPLATE_DIR / template).read_text(encoding="utf-8")
+    unstamped = [
+        m.group("path")
+        for m in STATIC_REF.finditer(source)
+        if (STATIC_DIR / m.group("path")).is_file()
+        and "/" not in m.group("path")
+        and not m.group("suffix").startswith("?v=")
+    ]
+    assert not unstamped, f"{template} loads {unstamped} without a ?v= stamp"
+
+
+def test_terminal_page_serves_stamped_routing_script(tmp_path, monkeypatch):
+    client = _authed_client(tmp_path, monkeypatch)
+    body = client.get("/terminal").text
+    stamp = main_mod._asset_versions()["terminal-routing.js"]
+    assert f"terminal-routing.js?v={stamp}" in body


### PR DESCRIPTION
The session rail rendered empty with "No active sessions" while hive-comms was returning live sessions and their ptys were still alive.

`terminal-routing.js` was loaded with no `?v=` stamp while `style.css` was stamped. When `contrastText` moved out of `terminal.html` into `terminal-routing.js`, a browser holding the cached script ran the fresh template against the old module: `TerminalRouting.contrastText` was `undefined`, calling it threw a TypeError inside `renderCards`, and the loop aborted before a single card was appended or the empty-state flag was recomputed. Only sessions with a color assigned reach that branch, which is why it surfaced immediately after color work and looked like the terminals themselves had died.

`_asset_versions()` now enumerates the top level of `static/` rather than listing two filenames by hand, so a hardcoded list can't silently stop covering a new asset again. `pr.html` had a second, unstamped `style.css` load that `layout.html` already covers; removed.

Tests: `tests/test_asset_versions.py` — the version map covers every first-party static file and moves with mtime, no template references a mutable top-level asset without a `?v=`, and `/terminal` actually serves the stamped script URL. The template scan caught the `pr.html` duplicate. Suite is 113 passed plus the node routing test.