### PR TITLE
terminal: measure the tile before opening the pty socket

### DIFF
--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -260,6 +260,25 @@
             fitRaf = requestAnimationFrame(function () { fitRaf = null; doFit(); });
         }
         const resizeObserver = new ResizeObserver(scheduleFit);
+        // The attach URL's cols/rows become the pty's spawn geometry, so the
+        // measurement has to happen before the socket opens. A tile mounted
+        // into a stage that hasn't been laid out yet — which on mobile is
+        // every tile, since the rail is showing when you tap a card — has a
+        // zero-sized box, FitAddon's proposeDimensions declines to guess,
+        // and xterm silently keeps its 80x24 default. The TUI then paints
+        // its first screen for a terminal nearly twice the width of the
+        // phone showing it. Wait for a real box, then measure, then attach.
+        function fitWhenSized(done, attempts) {
+            const n = attempts || 0;
+            if (xtermEl.clientWidth > 0 && xtermEl.clientHeight > 0) {
+                try { fitAddon.fit(); } catch (e) {}
+                done();
+            } else if (n >= 60) {
+                done();  // ~1s of frames; attach at the default rather than never
+            } else {
+                requestAnimationFrame(function () { fitWhenSized(done, n + 1); });
+            }
+        }
         function doFit() {
             const before = term.cols + "x" + term.rows;
             try { fitAddon.fit(); } catch (e) {}
@@ -645,10 +664,9 @@
             mindId: function () { return mindId; },
             mount: function () {
                 term.open(xtermEl);
-                fitAddon.fit();
                 resizeObserver.observe(xtermEl);
                 applyLabel();
-                attach();
+                fitWhenSized(attach);
             },
             fit: doFit,
             focus: function () { setFocusedPanel(panel); term.focus(); },

--- a/tests/test_terminal_sizing.py
+++ b/tests/test_terminal_sizing.py
@@ -1,0 +1,56 @@
+"""The pty is spawned at the tile's real geometry, not xterm's default.
+
+The attach URL's cols/rows become the pty's spawn size, so the tile has to
+be measured before the socket opens. Mounting into a stage that hasn't
+been laid out yet — on mobile that's every tile, since the rail is what's
+on screen when you tap a card — leaves the box at zero, FitAddon declines
+to guess, and xterm keeps 80x24. Every attach in the mind's log carried
+cols=80&rows=24 while phone tiles render around 44 columns, and the TUI
+painted its first screen almost twice as wide as the screen showing it.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from main import BASE_DIR
+
+
+TERMINAL_HTML = (BASE_DIR / "templates" / "terminal.html").read_text(encoding="utf-8")
+
+
+def _body(name: str) -> str:
+    """Source of `function <name>(` up to the next top-level function."""
+    start = TERMINAL_HTML.index("function " + name + "(")
+    rest = TERMINAL_HTML[start + 1:]
+    end = rest.find("\n        function ")
+    return rest if end == -1 else rest[:end]
+
+
+def test_mount_measures_before_attaching():
+    block = TERMINAL_HTML[TERMINAL_HTML.index("mount: function ()"):]
+    block = block[: block.index("},")]
+    assert "fitWhenSized(attach)" in block
+    # A bare fit() here is the bug: it measures a box that has no size yet.
+    assert not re.search(r"\bfitAddon\.fit\(\)", block)
+    assert not re.search(r"^\s*attach\(\);", block, re.MULTILINE)
+
+
+def test_fit_when_sized_waits_for_a_real_box():
+    body = _body("fitWhenSized")
+    assert "clientWidth > 0" in body and "clientHeight > 0" in body
+    assert "requestAnimationFrame" in body
+    # It must give up eventually rather than leaving a tile unattached
+    # forever if the box never gains a size.
+    assert re.search(r"n\s*>=\s*\d+", body)
+
+
+def test_attach_url_carries_the_measured_geometry():
+    block = TERMINAL_HTML[TERMINAL_HTML.index("function attach()"):]
+    block = block[: block.index("socket.onmessage")]
+    assert "wsUrl(sessionId, term.cols, term.rows)" in block
+    # and re-asserts it once the socket is live, in case the box changed
+    # shape between the measurement and the connection completing
+    assert "sendResize()" in block


### PR DESCRIPTION
The attach URL's `cols`/`rows` become the pty's spawn geometry, so the tile has to be measured before the socket opens. `mount()` called `fitAddon.fit()` immediately after `term.open()`, on a box the browser had not laid out yet — and on mobile that's every tile, because the rail is what's on screen when you tap a card, so the stage is still hidden. FitAddon's `proposeDimensions` declines to guess for a zero-sized element, `fit()` silently no-ops, and xterm keeps its 80x24 default.

Every single attach in the mind's journal carried `cols=80&rows=24`, across hours, desktop and phone alike, while a phone tile renders around 44 columns. The TUI's first paint was therefore laid out for a terminal nearly twice the width of the screen showing it.

`fitWhenSized` waits for a non-zero box before measuring, then attaches, and gives up after roughly a second of frames so a tile that never gains a size still connects rather than hanging unattached forever.

Tests: `tests/test_terminal_sizing.py` pins that mount measures before attaching and no longer calls `fit()` on an unlaid-out box, that the wait loop keys on real client dimensions and is bounded, and that the attach URL carries the measured geometry with a `sendResize` re-assertion once the socket is live. Suite 116 passed plus the node routing test.

Paired with hive_mind_skippy PR 19, which stops a pty replaying scrollback captured at a different width.