### PR TITLE
terminal: the IME preview bubble wraps at the tile, not at the cursor's leftovers

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1147,12 +1147,27 @@ body:has(.terminal-page) .content-wrapper > .terminal-box { display: none; }
 }
 .term-xterm .xterm { height: 100%; }
 
-/* xterm's own composition-view (the floating IME preview bubble, used
-   heavily by mobile soft keyboards) ships with white-space: nowrap and no
-   width cap -- on a narrow phone it runs off the right edge instead of
-   wrapping. Override with higher specificity than xterm.css's
-   .xterm .composition-view since load order alone can't be relied on. */
+/* xterm's own composition-view (the floating IME preview bubble that mobile
+   soft keyboards and voice typing paint into) ships with white-space: nowrap
+   and no width cap, so on a narrow phone it runs off the right edge instead
+   of wrapping. Wrapping it needs a real width to wrap AT, and it has none by
+   default: the bubble lives in .xterm-helpers, which xterm leaves at zero
+   width because every child of it is absolutely positioned, and it is itself
+   absolutely positioned at the cursor's x offset. So a percentage cap
+   resolves against nothing and shrink-to-fit gets only the sliver of space
+   to the right of the cursor -- which is how voice typing came out as one
+   character per line running straight down the tile.
+
+   Stretch the helper layer to the terminal's width so percentages mean
+   something, and pin the bubble to its left edge (xterm writes `left` inline
+   on every composition update, hence !important) so it wraps at the tile
+   rather than at whatever room the cursor happened to leave. */
+.term-panel .xterm .xterm-helpers {
+    left: 0;
+    right: 0;
+}
 .term-panel .xterm .composition-view {
+    left: 0.5rem !important;
     max-width: calc(100% - 1rem);
     white-space: pre-wrap;
     word-break: break-word;

--- a/tests/test_terminal_composition_view.py
+++ b/tests/test_terminal_composition_view.py
@@ -1,0 +1,60 @@
+"""The IME preview bubble wraps at the tile, not at the cursor's leftovers.
+
+xterm paints in-progress soft-keyboard and voice-typing text into a
+.composition-view div that lives inside .xterm-helpers. Every child of that
+helper layer is absolutely positioned, so the layer itself computes to zero
+width, and the bubble is absolutely positioned at the cursor's x offset
+inside it. Allowing the bubble to wrap without fixing either of those means
+a percentage cap resolves against zero and shrink-to-fit is handed only the
+sliver of room to the right of the cursor: Android voice typing came out as
+one character per line running straight down the tile.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from main import BASE_DIR
+
+
+STYLE_CSS = (BASE_DIR / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _rule(selector: str) -> str:
+    """Declarations of the last rule with this exact selector."""
+    matches = re.findall(
+        re.escape(selector) + r"\s*\{([^}]*)\}", STYLE_CSS
+    )
+    assert matches, f"no rule for {selector}"
+    return matches[-1]
+
+
+def test_helper_layer_is_stretched_so_percentages_resolve():
+    # Without this the bubble's max-width is a percentage of zero.
+    helpers = _rule(".term-panel .xterm .xterm-helpers")
+    assert re.search(r"\bleft:\s*0\b", helpers)
+    assert re.search(r"\bright:\s*0\b", helpers)
+
+
+def test_bubble_is_pinned_left_over_xterms_inline_offset():
+    # xterm rewrites `left` inline on every composition update, so only an
+    # !important declaration keeps the bubble off the cursor's x offset.
+    view = _rule(".term-panel .xterm .composition-view")
+    left = re.search(r"\bleft:\s*([^;]+);", view)
+    assert left, "composition-view must pin its left edge"
+    assert "!important" in left.group(1)
+
+
+def test_bubble_wraps_within_the_tile():
+    view = _rule(".term-panel .xterm .composition-view")
+    assert re.search(r"white-space:\s*pre-wrap", view)
+    assert re.search(r"word-break:\s*break-word", view)
+    assert re.search(r"max-width:\s*calc\(100% - 1rem\)", view)
+
+
+def test_the_bubble_rule_still_outranks_xterms_own():
+    # xterm.css ships `.xterm .composition-view { white-space: nowrap }`;
+    # the override wins on specificity rather than on load order.
+    assert ".term-panel .xterm .composition-view" in STYLE_CSS


### PR DESCRIPTION
Android voice typing painted its words one character per line, straight down the tile.

xterm shows in-progress soft-keyboard text in a `.composition-view` div inside `.xterm-helpers`. Every child of that helper layer is absolutely positioned, so the layer computes to zero width, and the bubble is itself absolutely positioned at the cursor's x offset inside it. The previous change let the bubble wrap without giving it anything to wrap at: `max-width: calc(100% - 1rem)` resolved against zero, and shrink-to-fit was handed only the sliver of room to the right of the cursor. Voice typing keeps one long composition open, so the whole utterance rendered into a one-character-wide column.

Stretches the helper layer to the terminal's width so percentages mean something, and pins the bubble to its left edge — xterm rewrites `left` inline on every composition update, hence `!important` — so it wraps at the tile.

120 pytest and 14 node routing tests green.