### PR TITLE
terminal: Enter forwards the open composition, not the whole IME box

### DIFF
--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -91,10 +91,45 @@
         return lum > 0.6 ? "#0b1724" : "#f4f8fb";
     }
 
+    /**
+     * The slice of xterm's helper textarea that Enter has to forward by
+     * hand, given xterm's own composition state.
+     *
+     * Mobile keyboards type into that textarea through IME compositions,
+     * and xterm does not clear it between words — it holds the whole line
+     * and each composition is sent as it ends, from its own start offset
+     * to the end of the box. So by the time Enter arrives, everything up
+     * to the open composition's start is already down the wire. Forwarding
+     * the whole box (the first cut of the mobile-Enter fix) resends the
+     * entire paragraph and the pty shows it twice.
+     *
+     * Nothing is owed when no composition is open or in flight: xterm has
+     * already sent it all. When one is, xterm is about to either drop it
+     * (Enter finalizes with commit=false) or slice it against a stale end
+     * offset, so this is the text that would otherwise be lost.
+     *
+     * @param {Object} state  xterm's composition state:
+     *                        {composing, flushPending, start, alreadySent}
+     * @param {string} value  the helper textarea's current value
+     * @returns {string} the text to send before the carriage return
+     */
+    function pendingImeText(state, value) {
+        var text = String(value == null ? "" : value);
+        if (!state || !text) return "";
+        if (!state.composing && !state.flushPending) return "";
+        // Text the non-composition path sent after the composition
+        // recorded its start offset sits between the two; xterm applies
+        // the same correction when it flushes.
+        var start = (state.start || 0) + String(state.alreadySent || "").length;
+        if (!(start >= 0) || start >= text.length) return "";
+        return text.slice(start);
+    }
+
     root.TerminalRouting = {
         pickReattachTarget: pickReattachTarget,
         isActive: isActive,
         retryDelayMs: retryDelayMs,
         contrastText: contrastText,
+        pendingImeText: pendingImeText,
     };
 })(typeof globalThis !== "undefined" ? globalThis : this);

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -543,6 +543,7 @@
             ws = socket;
         }
         term.onData(function (text) {
+            if (!text) return;
             if (ws && ws.readyState === WebSocket.OPEN) {
                 ws.send(new TextEncoder().encode(text));
             }
@@ -552,22 +553,47 @@
         // fires; xterm.js then discards the still-open composition instead
         // of sending it (CompositionHelper.keydown -> finalizeComposition
         // with commit=false), so the whole line silently vanishes and only
-        // a bare return reaches the pty. Forward whatever's still buffered
-        // in the helper textarea ourselves, ahead of xterm's own handler --
-        // a capture-phase listener on this ancestor runs before any
-        // listener on the textarea itself, composing or not -- then let
-        // Enter continue through the normal path.
+        // a bare return reaches the pty.
+        //
+        // Only the open composition is owed, though. xterm never clears the
+        // helper textarea between words, so it holds the whole line, and
+        // every earlier word already went to the pty as its own composition
+        // ended. Forwarding the box wholesale sends the paragraph a second
+        // time -- which is what the pty then echoed, the typed text
+        // concatenated with a copy of itself.
+        function pendingImeText() {
+            const ta = term.textarea;
+            const helper = term._core && term._core._compositionHelper;
+            if (!ta || !helper) return "";
+            const pos = helper._compositionPosition || {};
+            return TerminalRouting.pendingImeText({
+                composing: helper._isComposing,
+                // A composition that has ended but whose flush is still on
+                // xterm's 0ms timer: Enter cancels that flush, so the text
+                // is ours to send.
+                flushPending: helper._isSendingComposition,
+                start: pos.start,
+                alreadySent: helper._dataAlreadySent,
+            }, ta.value);
+        }
+        // Emptying the box first leaves xterm's own finalize with nothing to
+        // re-send, so its Enter path runs untouched: composition state
+        // resets, the preview bubble closes, the carriage return goes out.
+        function flushPendingIme() {
+            const ta = term.textarea;
+            const pending = pendingImeText();
+            if (pending && ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(new TextEncoder().encode(pending));
+            }
+            if (ta) ta.value = "";
+        }
+        // Capture-phase on this ancestor runs before any listener on the
+        // textarea itself, composing or not, so this lands ahead of xterm's
+        // own handler.
         xtermEl.addEventListener("keydown", function (e) {
             if (e.key !== "Enter" && e.keyCode !== 13) return;
-            const helperTa = xtermEl.querySelector(".xterm-helper-textarea");
-            if (helperTa && helperTa.value) {
-                if (ws && ws.readyState === WebSocket.OPEN) {
-                    ws.send(new TextEncoder().encode(helperTa.value));
-                }
-                helperTa.value = "";
-            }
+            flushPendingIme();
         }, true);
-        term.textarea && term.textarea.addEventListener("focus", function () { setFocusedPanel(panel); });
         el.addEventListener("mousedown", function () { setFocusedPanel(panel); });
 
         // ── rotation reattach ─────────────────────────────────────
@@ -664,6 +690,8 @@
             mindId: function () { return mindId; },
             mount: function () {
                 term.open(xtermEl);
+                // term.textarea only exists once xterm has opened.
+                term.textarea.addEventListener("focus", function () { setFocusedPanel(panel); });
                 resizeObserver.observe(xtermEl);
                 applyLabel();
                 fitWhenSized(attach);
@@ -672,6 +700,12 @@
             focus: function () { setFocusedPanel(panel); term.focus(); },
             refreshLabel: applyLabel,
             sendBytes: function (text) {
+                // The toolbar's return key never reaches xterm's keydown
+                // path, so an open composition would sit in the helper
+                // textarea and arrive after the newline, on the next
+                // prompt. Same debt as the hardware Enter, paid the same
+                // way.
+                if (text === "\r") flushPendingIme();
                 if (ws && ws.readyState === WebSocket.OPEN) {
                     ws.send(new TextEncoder().encode(text));
                 }

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -14,7 +14,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 // The module is a browser script, not an ES module — evaluate it the way a
 // <script> tag would, against globalThis.
 new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
-const {pickReattachTarget, isActive, retryDelayMs, contrastText} = globalThis.TerminalRouting;
+const {pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText} = globalThis.TerminalRouting;
 
 const tests = {
     "a live session is retried, not replaced"() {
@@ -132,6 +132,43 @@ const tests = {
         assert.equal(isActive({status: "closed"}), false);
         assert.equal(isActive({}), false);
         assert.equal(isActive(null), false);
+    },
+
+    "a settled IME box owes nothing to Enter"() {
+        // The whole paragraph is still sitting in xterm's helper textarea
+        // because xterm never clears it between words, but every word went
+        // to the pty as its own composition ended. Forwarding it again is
+        // what doubled Daniel's typed text.
+        const settled = {composing: false, flushPending: false, start: 0, alreadySent: ""};
+        assert.equal(pendingImeText(settled, "the whole paragraph"), "");
+    },
+
+    "an open composition is forwarded from its own start"() {
+        // "hello " already went out; "world" is mid-composition and would
+        // be discarded by xterm's Enter path.
+        const open = {composing: true, flushPending: false, start: 6, alreadySent: ""};
+        assert.equal(pendingImeText(open, "hello world"), "world");
+    },
+
+    "a composition whose flush Enter is about to cancel is forwarded"() {
+        const inFlight = {composing: false, flushPending: true, start: 6, alreadySent: ""};
+        assert.equal(pendingImeText(inFlight, "hello world"), "world");
+    },
+
+    "text sent after the composition recorded its start is not resent"() {
+        // xterm's non-composition path can deliver characters between
+        // compositionstart and the flush; it corrects the offset by their
+        // length and so must this.
+        const state = {composing: true, flushPending: false, start: 6, alreadySent: "wo"};
+        assert.equal(pendingImeText(state, "hello world"), "rld");
+    },
+
+    "an empty or exhausted box owes nothing"() {
+        const open = {composing: true, flushPending: false, start: 11, alreadySent: ""};
+        assert.equal(pendingImeText(open, "hello world"), "");
+        assert.equal(pendingImeText(open, ""), "");
+        assert.equal(pendingImeText(open, null), "");
+        assert.equal(pendingImeText(null, "hello"), "");
     },
 };
 

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -127,7 +127,6 @@ def test_template_forwards_mobile_ime_text_before_enter():
     with open(template, encoding="utf-8") as fh:
         body = fh.read()
 
-    assert "xterm-helper-textarea" in body
     assert 'e.key !== "Enter" && e.keyCode !== 13' in body
     # Must be capture-phase (the trailing `true`) on an ancestor of the
     # textarea (xtermEl), not the textarea itself -- a same-element listener
@@ -135,6 +134,48 @@ def test_template_forwards_mobile_ime_text_before_enter():
     idx = body.index('xtermEl.addEventListener("keydown"')
     listener_call = body[idx : idx + 500]
     assert "}, true);" in listener_call
+
+
+def test_enter_forwards_only_the_open_composition_not_the_whole_box():
+    """xterm never clears its helper textarea between words, so the box
+    holds the whole line while each composition has already gone to the pty
+    as it ended. The first cut of the Enter forwarder sent the box
+    wholesale, and the pty echoed the typed paragraph concatenated with a
+    copy of itself. Only the open composition is owed."""
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+
+    assert "TerminalRouting.pendingImeText(" in body
+    # The whole value must never be what goes on the wire.
+    assert "encode(helperTa.value)" not in body
+    # The toolbar's return key bypasses xterm's keydown path entirely, so
+    # it has to settle the same debt.
+    assert 'if (text === "\\r") flushPendingIme();' in body
+
+
+def test_vendored_xterm_still_exposes_the_composition_state_we_read():
+    """`pendingImeText` is fed from xterm's own composition state rather
+    than a private guess at it. Those are internals: if xterm is
+    re-vendored and renames them, the terminal would silently go back to
+    swallowing every dictated line. Fail here instead, pointing at
+    `pendingImeText` in terminal.html."""
+    bundle = os.path.join(
+        os.path.dirname(__file__), "..", "src", "static", "vendor", "xterm", "xterm.js"
+    )
+    with open(bundle, encoding="utf-8") as fh:
+        body = fh.read()
+
+    for symbol in (
+        "_compositionHelper",
+        "_compositionPosition",
+        "_isComposing",
+        "_isSendingComposition",
+        "_dataAlreadySent",
+    ):
+        assert symbol in body, f"vendored xterm no longer has {symbol}"
 
 
 def test_composition_view_wraps_on_mobile():


### PR DESCRIPTION
Typing a paragraph on a mobile keyboard and submitting it echoed the paragraph concatenated with a copy of itself.

xterm never clears its helper textarea between words: the box holds the entire typed line, and each composition has already gone to the pty as it ended. The mobile-Enter forwarder — added so a still-open composition isn't silently discarded — sent the box wholesale, so everything already on the wire went out a second time.

Now it asks xterm what it still owes. Forward only from the open composition's start offset (corrected by whatever the non-composition path sent after that offset was recorded), and nothing at all when no composition is open or in flight. Emptying the box before the event propagates leaves xterm's own finalize with nothing to re-send, so its Enter path still resets composition state, closes the preview bubble, and sends the carriage return.

The toolbar's return key never reaches xterm's keydown path at all, so it settles the same debt; previously an open composition arrived after the newline, on the next prompt.

Also drops a dead focus listener that bound `term.textarea` before `term.open()` had created it.

Tests: five node cases over the new pure `TerminalRouting.pendingImeText`, a template guard that the whole box is never what goes on the wire, and a guard that the vendored xterm still exposes the composition state this reads — so a re-vendor fails loudly here instead of silently swallowing dictated lines. 122 pytest, 19 node, all green.