### PR TITLE
terminal: give the phone a way into the tile's scrollback

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1147,6 +1147,19 @@ body:has(.terminal-page) .content-wrapper > .terminal-box { display: none; }
 }
 .term-xterm .xterm { height: 100%; }
 
+/* A phone has no visible scrollbar and no PageUp key, so the tile's
+   scrollback was unreachable by anything but a drag: a reply taller than
+   the screen was simply cut off with no way to read the rest. The toolbar
+   carries the deliberate controls; this keeps the drag itself honest, so a
+   vertical pan scrolls the terminal rather than rubber-banding the page,
+   and a pan that runs out of scrollback stops there instead of chaining
+   outward. */
+.term-panel .xterm .xterm-viewport {
+    touch-action: pan-y;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+}
+
 /* xterm's own composition-view (the floating IME preview bubble that mobile
    soft keyboards and voice typing paint into) ships with white-space: nowrap
    and no width cap, so on a narrow phone it runs off the right edge instead
@@ -1236,7 +1249,7 @@ body:has(.terminal-page) .content-wrapper > .terminal-box { display: none; }
 /* ── mobile key toolbar ───────────────────────────────── */
 .term-mobile-toolbar {
     display: none;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     gap: 0.4rem;
     padding: 0.4rem 0.5rem;
     background: #0b1724;

--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -125,7 +125,23 @@
         return text.slice(start);
     }
 
+    /**
+     * How far one press of the tile's PgUp/PgDn moves the viewport.
+     *
+     * A whole screen at a time loses the reader's place, so two rows of
+     * overlap carry over. A tile too short for that still has to move by
+     * something, hence the floor of one.
+     *
+     * @param {number} rows  the terminal's current row count
+     * @returns {number} lines to scroll, always at least 1
+     */
+    function pageScrollLines(rows) {
+        var n = Math.floor(Number(rows)) || 0;
+        return Math.max(1, n - 2);
+    }
+
     root.TerminalRouting = {
+        pageScrollLines: pageScrollLines,
         pickReattachTarget: pickReattachTarget,
         isActive: isActive,
         retryDelayMs: retryDelayMs,

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -35,11 +35,13 @@
         <button type="button" data-seq="&#x1b;">Esc</button>
         <button type="button" data-seq="&#x09;">Tab</button>
         <button type="button" data-seq="&#x03;">Ctrl+C</button>
-        <button type="button" data-seq="&#x0d;">&crarr;</button>
+        <button type="button" data-scroll="-1" aria-label="scroll back a page">PgUp</button>
+        <button type="button" data-scroll="1" aria-label="scroll forward a page">PgDn</button>
         <button type="button" data-seq="&#x1b;[D">&larr;</button>
         <button type="button" data-seq="&#x1b;[A">&uarr;</button>
         <button type="button" data-seq="&#x1b;[B">&darr;</button>
         <button type="button" data-seq="&#x1b;[C">&rarr;</button>
+        <button type="button" data-seq="&#x0d;">&crarr;</button>
     </div>
 </main>
 
@@ -699,6 +701,9 @@
             fit: doFit,
             focus: function () { setFocusedPanel(panel); term.focus(); },
             refreshLabel: applyLabel,
+            scrollPage: function (dir) {
+                term.scrollLines(dir * TerminalRouting.pageScrollLines(term.rows));
+            },
             sendBytes: function (text) {
                 // The toolbar's return key never reaches xterm's keydown
                 // path, so an open composition would sit in the helper
@@ -977,10 +982,20 @@
 
     // ── mobile key toolbar (routes to the focused tile) ───────────
     toolbar.addEventListener("click", function (ev) {
-        const btn = ev.target.closest("button[data-seq]");
+        const btn = ev.target.closest("button[data-seq], button[data-scroll]");
         if (!btn) return;
         const target = focusedPanel || openPanels.values().next().value;
-        if (target) target.sendBytes(btn.dataset.seq);
+        if (!target) return;
+        // Scrollback is a property of the tile, not of the pty: a phone has
+        // no visible scrollbar and no PageUp key, so a reply taller than the
+        // screen had nothing to reach the rest of it with. These move the
+        // viewport; they must never go down the wire as key bytes, which the
+        // TUI would act on instead.
+        if (btn.dataset.scroll) {
+            target.scrollPage(Number(btn.dataset.scroll));
+            return;
+        }
+        target.sendBytes(btn.dataset.seq);
     });
 
     // ── boot ──────────────────────────────────────────────────────

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -14,7 +14,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 // The module is a browser script, not an ES module — evaluate it the way a
 // <script> tag would, against globalThis.
 new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
-const {pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText} = globalThis.TerminalRouting;
+const {
+    pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText, pageScrollLines,
+} = globalThis.TerminalRouting;
 
 const tests = {
     "a live session is retried, not replaced"() {
@@ -132,6 +134,19 @@ const tests = {
         assert.equal(isActive({status: "closed"}), false);
         assert.equal(isActive({}), false);
         assert.equal(isActive(null), false);
+    },
+
+    "a page of scrollback keeps two rows of overlap"() {
+        assert.equal(pageScrollLines(24), 22);
+        assert.equal(pageScrollLines(40.7), 38);
+    },
+
+    "a tile too short to overlap still moves"() {
+        // Never 0: a button that does nothing reads as a broken terminal.
+        assert.equal(pageScrollLines(2), 1);
+        assert.equal(pageScrollLines(1), 1);
+        assert.equal(pageScrollLines(0), 1);
+        assert.equal(pageScrollLines(undefined), 1);
     },
 
     "a settled IME box owes nothing to Enter"() {

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -12,6 +12,7 @@ exercised by ``tests/js/terminal_routing_test.mjs``, run here so one
 """
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -231,3 +232,42 @@ def test_terminal_has_redundant_refit_signals_for_foldables():
     assert "window.visualViewport.addEventListener(\"resize\"" in body
     assert 'window.addEventListener("orientationchange"' in body
     assert "setInterval(refitAllPanels" in body
+
+
+def test_mobile_toolbar_can_reach_the_tiles_scrollback():
+    """A phone has no visible scrollbar and no PageUp key. Without deliberate
+    controls a reply taller than the screen is simply cut off, which is how
+    a whole answer became unreadable on mobile. The controls must move the
+    viewport, never send key bytes -- PageUp down the wire is something the
+    TUI acts on, not something that scrolls."""
+    template = os.path.join(
+        os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
+    )
+    with open(template, encoding="utf-8") as fh:
+        body = fh.read()
+
+    assert 'data-scroll="-1"' in body and 'data-scroll="1"' in body
+    assert "target.scrollPage(Number(btn.dataset.scroll));" in body
+    # The scroll buttons must not be reachable as byte-sending keys.
+    idx = body.index('toolbar.addEventListener("click"')
+    handler = body[idx : idx + 900]
+    assert handler.index("dataset.scroll") < handler.index("sendBytes")
+    assert "TerminalRouting.pageScrollLines(term.rows)" in body
+
+    css_path = os.path.join(
+        os.path.dirname(__file__), "..", "src", "static", "style.css"
+    )
+    with open(css_path, encoding="utf-8") as fh:
+        css = fh.read()
+
+    # Ten keys over five columns; four would strand two on a half row.
+    assert re.search(
+        r"\.term-mobile-toolbar\s*\{[^}]*grid-template-columns:\s*repeat\(5,", css
+    )
+    # A vertical drag scrolls the terminal instead of rubber-banding the page.
+    viewport = re.search(
+        r"\.term-panel \.xterm \.xterm-viewport\s*\{([^}]*)\}", css
+    )
+    assert viewport, "no viewport rule"
+    assert "touch-action: pan-y" in viewport.group(1)
+    assert "overscroll-behavior: contain" in viewport.group(1)


### PR DESCRIPTION
A reply taller than the screen was unreadable on mobile: the tile keeps 5000 lines of scrollback, but a phone has no visible scrollbar and no PageUp key, so the only route into any of it was a drag that gives no sign it exists.

The keys toolbar gets PgUp and PgDn, moving the viewport by a screen less two rows of overlap. They scroll the tile rather than sending key bytes — PageUp down the wire is something the TUI acts on, not something that scrolls. Ten keys now, so the grid goes to five columns and stays two rows, with the return key ending the second.

The viewport also keeps vertical drags for itself: a pan scrolls the terminal instead of rubber-banding the page, and stops at the end of the scrollback instead of chaining outward.

Tests: node cases over the new pure `TerminalRouting.pageScrollLines` (overlap, and never a no-op on a short tile), plus a template and CSS guard that the scroll buttons are handled before the byte-sending path and that the toolbar grid fits ten keys in two rows. 123 pytest, 21 node, all green.