### PR TITLE
terminal: dictating no longer walks the terminal sideways

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+playwright

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1186,6 +1186,23 @@ body:has(.terminal-page) .content-wrapper > .terminal-box { display: none; }
     word-break: break-word;
 }
 
+/* The hidden textarea has to be pinned for the same reason, and it is the
+   wrap above that makes it urgent. While a composition is open xterm parks
+   the textarea just past the bubble and gives it the bubble's width, so a
+   bubble as wide as the tile puts a focused element a whole tile-width off
+   the right edge. Nothing clips it -- the tile only has overflow: hidden,
+   which is scrollable, so the browser scrolls the terminal sideways to keep
+   the thing it thinks you are editing in view, and the content marches left
+   as you dictate. Held at the origin at one pixel wide, composition can't
+   move it and there is no overflow to chase. It is invisible either way
+   (opacity 0, z-index -5); the only cost is that a desktop IME candidate
+   window opens at the tile's corner rather than at the cursor. */
+.term-panel .xterm .xterm-helper-textarea {
+    left: 0 !important;
+    width: 1px !important;
+    max-width: 1px !important;
+}
+
 /* ── new-session mind picker ──────────────────────────── */
 .term-new-menu {
     display: flex;

--- a/tests/test_terminal_composition_overflow.py
+++ b/tests/test_terminal_composition_overflow.py
@@ -1,0 +1,181 @@
+"""Dictating into a tile must not walk the terminal sideways.
+
+While an IME composition is open, xterm parks its hidden textarea just past
+the preview bubble and gives it the bubble's width. Once that bubble was
+made to wrap at the tile, the bubble became as wide as the tile, so the
+focused textarea landed a whole tile-width off the right edge. Nothing
+clips it -- the tile's only containment is overflow: hidden, which is still
+scrollable -- so the browser scrolled the terminal sideways to keep the
+element it thought was being edited in view, and the content marched left
+with every dictated word.
+
+This is a real browser at a phone's viewport because the bug lives in the
+interaction between xterm's inline styles, this repo's CSS and the
+browser's scroll-into-view: nothing short of layout reproduces it.
+"""
+
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+playwright_api = pytest.importorskip(
+    "playwright.sync_api", reason="playwright is not installed"
+)
+
+import auth  # noqa: E402
+import main as main_mod  # noqa: E402
+
+PHONE = {"width": 412, "height": 780}
+SESSIONS = [
+    {
+        "id": "sess-1",
+        "mind_id": "mind-uuid",
+        "mind_name": "skippy",
+        "status": "running",
+        "short_id": "sess-1",
+    }
+]
+# Long enough that the bubble wraps and takes the full width of the tile,
+# which is what inflated the textarea.
+DICTATED = "this is what a whole dictated sentence looks like when it keeps going"
+
+
+@pytest.fixture(scope="module")
+def live_app():
+    """The real app on a real port — the page has to load its own assets."""
+    tmp = tempfile.mkdtemp()
+    os.environ["STB_DB_PATH"] = os.path.join(tmp, "stb.db")
+    os.environ["STB_SECRET_KEY"] = "browser-test-secret"
+
+    import uvicorn
+
+    user = auth.create_user("browser-test", "browser-pass", is_admin=True, replace=True)
+    token = auth.create_session_token(user)
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server = uvicorn.Server(
+        uvicorn.Config(main_mod.app, host="127.0.0.1", port=port, log_level="error")
+    )
+    threading.Thread(target=server.run, daemon=True).start()
+    for _ in range(100):
+        try:
+            socket.create_connection(("127.0.0.1", port), 0.2).close()
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        pytest.skip("app did not come up")
+
+    yield f"http://127.0.0.1:{port}", token
+    server.should_exit = True
+
+
+@pytest.fixture()
+def tile(live_app):
+    """One mounted terminal tile on a phone-sized screen, socket stubbed."""
+    base, token = live_app
+    with playwright_api.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:  # no browser binary installed
+            pytest.skip(f"chromium unavailable: {exc}")
+        ctx = browser.new_context(
+            viewport=PHONE, device_scale_factor=2.625, is_mobile=True, has_touch=True
+        )
+        ctx.add_cookies(
+            [
+                {
+                    "name": auth.SESSION_COOKIE_NAME,
+                    "value": token,
+                    "domain": "127.0.0.1",
+                    "path": "/",
+                }
+            ]
+        )
+        page = ctx.new_page()
+        page.route(
+            "**/api/terminal/sessions*",
+            lambda r: r.fulfill(
+                status=200, content_type="application/json", body=json.dumps(SESSIONS)
+            ),
+        )
+        page.route(
+            "**/api/terminal/labels*",
+            lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
+        )
+        page.route_web_socket(
+            "**/api/terminal/attach/**",
+            lambda ws: ws.send("skippy@box:~$ tell me about the thing"),
+        )
+        page.goto(base + "/terminal")
+        page.wait_for_selector(".term-card", timeout=15000)
+        page.click(".term-card")
+        page.wait_for_selector(".term-panel .xterm-viewport", timeout=15000)
+        page.wait_for_timeout(600)
+        yield page
+        browser.close()
+
+
+def _compose(page, text):
+    """Open an IME composition carrying `text`, as a soft keyboard does."""
+    return page.evaluate(
+        """(text) => {
+            const host = document.querySelector('.term-xterm');
+            const ta = host.querySelector('.xterm-helper-textarea');
+            ta.focus();
+            ta.dispatchEvent(new CompositionEvent('compositionstart', {bubbles: true}));
+            ta.value = text;
+            ta.dispatchEvent(new CompositionEvent('compositionupdate', {data: text, bubbles: true}));
+            const panel = document.querySelector('.term-panel');
+            const bubble = host.querySelector('.composition-view');
+            return {
+                panelScrollWidth: panel.scrollWidth,
+                panelClientWidth: panel.clientWidth,
+                textareaRight: ta.getBoundingClientRect().right,
+                bubbleWidth: bubble ? bubble.getBoundingClientRect().width : 0,
+                screenRight: host.querySelector('.xterm-screen').getBoundingClientRect().right,
+            };
+        }""",
+        text,
+    )
+
+
+def test_dictating_adds_no_sideways_overflow_to_the_tile(tile):
+    state = _compose(tile, DICTATED)
+    # The bug measured 682 against a 412 tile: a tile-width of scrollable
+    # overflow, which is what the browser then panned into view.
+    assert state["panelScrollWidth"] == state["panelClientWidth"]
+    assert state["textareaRight"] <= state["screenRight"] + 1
+
+
+def test_the_preview_bubble_still_gets_the_whole_tile_to_wrap_in(tile):
+    # The pin above must not be paid for by un-wrapping the bubble: it is
+    # the visible half of dictation and the reason the textarea inflates.
+    state = _compose(tile, DICTATED)
+    assert state["bubbleWidth"] > PHONE["width"] / 2
+
+
+def test_the_terminal_is_never_wider_than_the_tile_that_holds_it(tile):
+    # The measured fit is what the pty is spawned at, so a screen wider
+    # than its box means the TUI is drawing where nobody can see it.
+    fits = tile.evaluate(
+        """() => {
+            const host = document.querySelector('.term-xterm');
+            const screen = host.querySelector('.xterm-screen').getBoundingClientRect();
+            const viewport = host.querySelector('.xterm-viewport');
+            return {screenWidth: screen.width, viewportWidth: viewport.clientWidth};
+        }"""
+    )
+    assert fits["screenWidth"] <= fits["viewportWidth"]


### PR DESCRIPTION
Dictating into a tile scrolled the terminal sideways, pushing the content off the left edge a word at a time.

While an IME composition is open, xterm parks its hidden textarea just past the preview bubble and gives it the bubble's width. Making that bubble wrap at the tile (#28) made it as wide as the tile, so the focused textarea landed a whole tile-width off the right edge — measured at 682px against a 412px tile. Nothing clips it: the tile's only containment is `overflow: hidden`, which is still scrollable, so the browser scrolled the terminal to keep the element it thought was being edited in view.

Pinning the textarea at the origin, one pixel wide, over xterm's inline styles removes the overflow entirely. It is invisible either way (`opacity: 0`, `z-index: -5`); the only cost is that a desktop IME candidate window opens at the tile's corner rather than at the cursor.

Tested in a real browser at a phone's viewport — the bug lives in the interaction between xterm's inline styles, this repo's CSS and the browser's scroll-into-view, and nothing short of layout reproduces it. The new test fails on the old CSS with exactly the 682-against-412 overflow, and also holds the two invariants that got us here: the preview bubble still gets the whole tile to wrap in, and the terminal is never rendered wider than the box that holds it. Adds `requirements-dev.txt` for the test-only deps. 126 pytest, 21 node, all green.