### PR TITLE
terminal: scroll the program's history, not an empty viewport

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1147,13 +1147,14 @@ body:has(.terminal-page) .content-wrapper > .terminal-box { display: none; }
 }
 .term-xterm .xterm { height: 100%; }
 
-/* A phone has no visible scrollbar and no PageUp key, so the tile's
-   scrollback was unreachable by anything but a drag: a reply taller than
-   the screen was simply cut off with no way to read the rest. The toolbar
-   carries the deliberate controls; this keeps the drag itself honest, so a
-   vertical pan scrolls the terminal rather than rubber-banding the page,
-   and a pan that runs out of scrollback stops there instead of chaining
-   outward. */
+/* A phone has no visible scrollbar and no PageUp key, so a reply taller
+   than the screen was simply cut off with no way to read the rest. The
+   toolbar carries the deliberate controls and the tile converts drags
+   into wheel reports (the TUI holds the history, not the viewport — see
+   TerminalRouting.pageScrollAction). This keeps whatever the browser does
+   handle from working against that: a vertical pan belongs to the
+   terminal rather than rubber-banding the page, and it stops at the end
+   of the buffer instead of chaining outward. */
 .term-panel .xterm .xterm-viewport {
     touch-action: pan-y;
     overscroll-behavior: contain;

--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -140,8 +140,71 @@
         return Math.max(1, n - 2);
     }
 
+    /**
+     * Where a page of scrolling has to be done: here, or by the program.
+     *
+     * Claude's TUI takes the alternate screen buffer the moment it starts
+     * (ESC[?1049h) and turns on SGR mouse reporting. An alternate buffer
+     * has no scrollback by definition — xterm's own scrollLines has
+     * nothing to move and the viewport has no overflow to drag — so the
+     * conversation history the reader wants is inside the program's own
+     * scroll region, and only the program can move it. Sending the page
+     * keys down the wire is the fix, not the hazard: acting on them is
+     * precisely what is wanted. On the normal buffer the tile owns the
+     * scrollback and scrolls it locally, without disturbing the program.
+     *
+     * @param {Object} state  {altBuffer: boolean, rows: number, dir: -1|1}
+     * @returns {{kind: "bytes", data: string}|{kind: "lines", lines: number}}
+     */
+    function pageScrollAction(state) {
+        var dir = Number(state && state.dir) < 0 ? -1 : 1;
+        if (state && state.altBuffer) {
+            return {kind: "bytes", data: dir < 0 ? "\x1b[5~" : "\x1b[6~"};
+        }
+        return {kind: "lines", lines: dir * pageScrollLines(state && state.rows)};
+    }
+
+    /**
+     * One wheel notch as an SGR (1006) mouse report.
+     *
+     * Buttons 64 and 65 are wheel-up and wheel-down; the TUI enabled this
+     * encoding itself, so it is the channel it already listens on.
+     *
+     * @param {-1|1} dir      -1 scrolls back through history, 1 forward
+     * @param {number} col    1-based cell column of the pointer
+     * @param {number} row    1-based cell row of the pointer
+     */
+    function wheelReport(dir, col, row) {
+        var button = Number(dir) < 0 ? 64 : 65;
+        var x = Math.max(1, Math.floor(Number(col) || 1));
+        var y = Math.max(1, Math.floor(Number(row) || 1));
+        return "\x1b[<" + button + ";" + x + ";" + y + "M";
+    }
+
+    /**
+     * A touch drag, in wheel notches.
+     *
+     * A phone has no wheel and, on the alternate buffer, nothing for the
+     * browser to pan either, so a drag has to be converted by hand. A
+     * finger moving down pulls older lines into view, which is a wheel-up
+     * notch. Whatever distance doesn't fill a whole notch is returned so
+     * the caller can carry it into the next move rather than losing it.
+     *
+     * @param {number} deltaY         pixels moved since the last report
+     * @param {number} pixelsPerStep  drag distance one notch is worth
+     * @returns {{steps: number, dir: -1|1, consumed: number}}
+     */
+    function dragWheelSteps(deltaY, pixelsPerStep) {
+        var step = Math.abs(Number(pixelsPerStep)) || 24;
+        var n = Math.trunc((Number(deltaY) || 0) / step);
+        return {steps: Math.abs(n), dir: n > 0 ? -1 : 1, consumed: n * step};
+    }
+
     root.TerminalRouting = {
         pageScrollLines: pageScrollLines,
+        pageScrollAction: pageScrollAction,
+        wheelReport: wheelReport,
+        dragWheelSteps: dragWheelSteps,
         pickReattachTarget: pickReattachTarget,
         isActive: isActive,
         retryDelayMs: retryDelayMs,

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -544,12 +544,48 @@
             socket.onerror = () => setAttachState("connection error");
             ws = socket;
         }
-        term.onData(function (text) {
+        function sendRaw(text) {
             if (!text) return;
             if (ws && ws.readyState === WebSocket.OPEN) {
                 ws.send(new TextEncoder().encode(text));
             }
-        });
+        }
+        function isAltBuffer() {
+            const buf = term.buffer && term.buffer.active;
+            return !!buf && buf.type === "alternate";
+        }
+        term.onData(sendRaw);
+
+        // Scrolling by finger. On the alternate buffer — which is where
+        // the TUI lives, and so the only buffer this tile ever really
+        // shows — the viewport has no overflow, so the browser has
+        // nothing to pan and a drag does nothing at all. Translate it
+        // into the wheel reports the program turned on for itself.
+        let dragY = null;
+        let dragCell = {col: 1, row: 1};
+        xtermEl.addEventListener("touchstart", function (e) {
+            if (e.touches.length !== 1 || !isAltBuffer()) { dragY = null; return; }
+            const t = e.touches[0];
+            const box = xtermEl.getBoundingClientRect();
+            dragCell = {
+                col: Math.floor((t.clientX - box.left) / (box.width / term.cols)) + 1,
+                row: Math.floor((t.clientY - box.top) / (box.height / term.rows)) + 1,
+            };
+            dragY = t.clientY;
+        }, {passive: true});
+        xtermEl.addEventListener("touchmove", function (e) {
+            if (dragY === null || e.touches.length !== 1) return;
+            const t = e.touches[0];
+            const move = TerminalRouting.dragWheelSteps(t.clientY - dragY, 24);
+            if (!move.steps) return;
+            e.preventDefault();
+            dragY += move.consumed;
+            for (let i = 0; i < move.steps; i++) {
+                sendRaw(TerminalRouting.wheelReport(move.dir, dragCell.col, dragCell.row));
+            }
+        }, {passive: false});
+        xtermEl.addEventListener("touchend", function () { dragY = null; });
+        xtermEl.addEventListener("touchcancel", function () { dragY = null; });
         // Mobile virtual keyboards (Gboard, iOS predictive text) route typed
         // words through an IME composition that isn't closed before Enter
         // fires; xterm.js then discards the still-open composition instead
@@ -702,7 +738,11 @@
             focus: function () { setFocusedPanel(panel); term.focus(); },
             refreshLabel: applyLabel,
             scrollPage: function (dir) {
-                term.scrollLines(dir * TerminalRouting.pageScrollLines(term.rows));
+                const action = TerminalRouting.pageScrollAction({
+                    altBuffer: isAltBuffer(), rows: term.rows, dir: dir,
+                });
+                if (action.kind === "bytes") sendRaw(action.data);
+                else term.scrollLines(action.lines);
             },
             sendBytes: function (text) {
                 // The toolbar's return key never reaches xterm's keydown
@@ -711,9 +751,7 @@
                 // prompt. Same debt as the hardware Enter, paid the same
                 // way.
                 if (text === "\r") flushPendingIme();
-                if (ws && ws.readyState === WebSocket.OPEN) {
-                    ws.send(new TextEncoder().encode(text));
-                }
+                sendRaw(text);
             },
             destroy: function () {
                 destroyed = true;
@@ -986,11 +1024,10 @@
         if (!btn) return;
         const target = focusedPanel || openPanels.values().next().value;
         if (!target) return;
-        // Scrollback is a property of the tile, not of the pty: a phone has
-        // no visible scrollbar and no PageUp key, so a reply taller than the
-        // screen had nothing to reach the rest of it with. These move the
-        // viewport; they must never go down the wire as key bytes, which the
-        // TUI would act on instead.
+        // A phone has no visible scrollbar and no PageUp key, so a reply
+        // taller than the screen had nothing to reach the rest of it with.
+        // Where that scrolling happens depends on which buffer is up —
+        // see TerminalRouting.pageScrollAction — so the panel decides.
         if (btn.dataset.scroll) {
             target.scrollPage(Number(btn.dataset.scroll));
             return;

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -16,6 +16,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
 const {
     pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText, pageScrollLines,
+    pageScrollAction, wheelReport, dragWheelSteps,
 } = globalThis.TerminalRouting;
 
 const tests = {
@@ -176,6 +177,50 @@ const tests = {
         // length and so must this.
         const state = {composing: true, flushPending: false, start: 6, alreadySent: "wo"};
         assert.equal(pendingImeText(state, "hello world"), "rld");
+    },
+
+    "on the alternate buffer a page of scrolling is the program's to do"() {
+        // The whole bug: xterm's scrollback does not exist on the alt
+        // buffer, so scrolling it locally moved nothing at all.
+        assert.deepEqual(
+            pageScrollAction({altBuffer: true, rows: 27, dir: -1}),
+            {kind: "bytes", data: "\x1b[5~"},
+        );
+        assert.deepEqual(
+            pageScrollAction({altBuffer: true, rows: 27, dir: 1}),
+            {kind: "bytes", data: "\x1b[6~"},
+        );
+    },
+
+    "on the normal buffer the tile scrolls its own scrollback"() {
+        assert.deepEqual(
+            pageScrollAction({altBuffer: false, rows: 27, dir: -1}),
+            {kind: "lines", lines: -25},
+        );
+        assert.deepEqual(
+            pageScrollAction({altBuffer: false, rows: 27, dir: 1}),
+            {kind: "lines", lines: 25},
+        );
+    },
+
+    "a wheel notch is an SGR report the TUI already listens for"() {
+        assert.equal(wheelReport(-1, 12, 5), "\x1b[<64;12;5M");
+        assert.equal(wheelReport(1, 12, 5), "\x1b[<65;12;5M");
+        // Cells are 1-based; a pointer measured off the top-left edge
+        // must not report a zeroth column.
+        assert.equal(wheelReport(-1, 0, -3), "\x1b[<64;1;1M");
+    },
+
+    "a finger moving down pulls older lines into view"() {
+        assert.deepEqual(dragWheelSteps(60, 24), {steps: 2, dir: -1, consumed: 48});
+        assert.deepEqual(dragWheelSteps(-60, 24), {steps: 2, dir: 1, consumed: -48});
+    },
+
+    "drag distance short of a notch is carried, not lost"() {
+        // Slow drags are all short moves; discarding each one would make
+        // the tile ignore the gesture entirely.
+        assert.deepEqual(dragWheelSteps(20, 24), {steps: 0, dir: 1, consumed: 0});
+        assert.equal(dragWheelSteps(0, 24).steps, 0);
     },
 
     "an empty or exhausted box owes nothing"() {

--- a/tests/test_terminal_alt_buffer_scroll.py
+++ b/tests/test_terminal_alt_buffer_scroll.py
@@ -1,0 +1,203 @@
+"""The tile's page keys have to reach the program, not the viewport.
+
+Claude's TUI takes the alternate screen buffer on startup (it emits
+ESC[?1049h before its first paint) and turns on SGR mouse reporting. An
+alternate buffer has no scrollback: xterm's scrollLines moves nothing and
+the viewport has no overflow to drag, so PgUp/PgDn appeared to do nothing
+at all and the conversation history stayed unreachable on a phone. The
+history lives in the program's own scroll region, so the page keys and
+finger drags have to go down the wire.
+
+A real browser, because the thing under test is xterm's buffer state
+after a real escape sequence and the bytes a real click puts on the
+socket.
+"""
+
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+playwright_api = pytest.importorskip(
+    "playwright.sync_api", reason="playwright is not installed"
+)
+
+import auth  # noqa: E402
+import main as main_mod  # noqa: E402
+
+PHONE = {"width": 412, "height": 780}
+SESSIONS = [
+    {
+        "id": "sess-1",
+        "mind_id": "mind-uuid",
+        "mind_name": "skippy",
+        "status": "running",
+        "short_id": "sess-1",
+    }
+]
+# What the TUI actually sends first: alternate buffer, cleared, with SGR
+# mouse reporting on. Captured from a real `claude` under a pty.
+ENTER_ALT_SCREEN = "\x1b[?1049h\x1b[2J\x1b[H\x1b[?1000h\x1b[?1002h\x1b[?1006h"
+PGUP = "\x1b[5~"
+PGDN = "\x1b[6~"
+
+
+@pytest.fixture(scope="module")
+def live_app():
+    """The real app on a real port — the page has to load its own assets."""
+    tmp = tempfile.mkdtemp()
+    os.environ["STB_DB_PATH"] = os.path.join(tmp, "stb.db")
+    os.environ["STB_SECRET_KEY"] = "browser-test-secret"
+
+    import uvicorn
+
+    user = auth.create_user("browser-test", "browser-pass", is_admin=True, replace=True)
+    token = auth.create_session_token(user)
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server = uvicorn.Server(
+        uvicorn.Config(main_mod.app, host="127.0.0.1", port=port, log_level="error")
+    )
+    threading.Thread(target=server.run, daemon=True).start()
+    for _ in range(100):
+        try:
+            socket.create_connection(("127.0.0.1", port), 0.2).close()
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        pytest.skip("app did not come up")
+
+    yield f"http://127.0.0.1:{port}", token
+    server.should_exit = True
+
+
+def _open_tile(page, base, greeting):
+    """Mount one tile whose socket opens with `greeting`, recording sends."""
+    sent = []
+
+    page.route(
+        "**/api/terminal/sessions*",
+        lambda r: r.fulfill(
+            status=200, content_type="application/json", body=json.dumps(SESSIONS)
+        ),
+    )
+    page.route(
+        "**/api/terminal/labels*",
+        lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
+    )
+
+    def handle_ws(ws):
+        ws.on_message(
+            lambda m: sent.append(m if isinstance(m, str) else m.decode("utf8", "replace"))
+        )
+        ws.send(greeting)
+
+    page.route_web_socket("**/api/terminal/attach/**", handle_ws)
+    page.goto(base + "/terminal")
+    page.wait_for_selector(".term-card", timeout=15000)
+    page.click(".term-card")
+    page.wait_for_selector(".term-panel .xterm-viewport", timeout=15000)
+    page.wait_for_timeout(600)
+    return sent
+
+
+@pytest.fixture()
+def phone(live_app):
+    base, token = live_app
+    with playwright_api.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:  # no browser binary installed
+            pytest.skip(f"chromium unavailable: {exc}")
+        ctx = browser.new_context(
+            viewport=PHONE, device_scale_factor=2.625, is_mobile=True, has_touch=True
+        )
+        ctx.add_cookies(
+            [
+                {
+                    "name": auth.SESSION_COOKIE_NAME,
+                    "value": token,
+                    "domain": "127.0.0.1",
+                    "path": "/",
+                }
+            ]
+        )
+        yield ctx.new_page(), base
+        browser.close()
+
+
+def test_a_program_on_the_alternate_screen_gets_the_page_keys(phone):
+    page, base = phone
+    sent = _open_tile(page, base, ENTER_ALT_SCREEN + "the tail of a long reply")
+    sent.clear()
+
+    page.click('#term-mobile-toolbar button[data-scroll="-1"]')
+    page.click('#term-mobile-toolbar button[data-scroll="1"]')
+    page.wait_for_timeout(300)
+
+    assert "".join(sent) == PGUP + PGDN
+
+
+def test_a_finger_drag_becomes_the_wheel_reports_the_tui_asked_for(phone):
+    page, base = phone
+    sent = _open_tile(page, base, ENTER_ALT_SCREEN + "the tail of a long reply")
+    sent.clear()
+
+    box = page.locator(".term-xterm").bounding_box()
+    x = box["x"] + box["width"] / 2
+    y = box["y"] + box["height"] / 2
+    page.touchscreen.tap(x, y)  # a tap is an ordinary click, never a scroll
+    page.wait_for_timeout(150)
+    tap = "".join(sent)
+    assert "\x1b[<64;" not in tap and "\x1b[<65;" not in tap
+    sent.clear()
+
+    page.evaluate(
+        """([x, y]) => {
+            const host = document.querySelector('.term-xterm');
+            const touch = (cx, cy) => new Touch({identifier: 1, target: host, clientX: cx, clientY: cy});
+            const fire = (type, cx, cy) => host.dispatchEvent(new TouchEvent(type, {
+                bubbles: true, cancelable: true,
+                touches: type === 'touchend' ? [] : [touch(cx, cy)],
+                changedTouches: [touch(cx, cy)],
+            }));
+            fire('touchstart', x, y);
+            fire('touchmove', x, y + 80);   // dragging down = back in history
+            fire('touchend', x, y + 80);
+        }""",
+        [x, y],
+    )
+    page.wait_for_timeout(200)
+
+    wheel = "".join(sent)
+    assert wheel.count("\x1b[<64;") == 3  # 80px at 24px a notch
+    assert "\x1b[<65;" not in wheel
+
+
+def test_a_tile_with_its_own_scrollback_still_scrolls_locally(phone):
+    # The normal buffer is the tile's to scroll, and pushing page keys at
+    # a program that never asked for them would be a regression.
+    page, base = phone
+    lines = "".join("line %03d\r\n" % i for i in range(200))
+    sent = _open_tile(page, base, lines)
+    sent.clear()
+
+    before = page.evaluate("() => document.querySelector('.xterm-viewport').scrollTop")
+    page.click('#term-mobile-toolbar button[data-scroll="-1"]')
+    page.wait_for_timeout(300)
+    after = page.evaluate("() => document.querySelector('.xterm-viewport').scrollTop")
+
+    assert after < before
+    assert sent == []

--- a/tests/test_terminal_routing.py
+++ b/tests/test_terminal_routing.py
@@ -237,9 +237,10 @@ def test_terminal_has_redundant_refit_signals_for_foldables():
 def test_mobile_toolbar_can_reach_the_tiles_scrollback():
     """A phone has no visible scrollbar and no PageUp key. Without deliberate
     controls a reply taller than the screen is simply cut off, which is how
-    a whole answer became unreadable on mobile. The controls must move the
-    viewport, never send key bytes -- PageUp down the wire is something the
-    TUI acts on, not something that scrolls."""
+    a whole answer became unreadable on mobile. Where the scrolling has to
+    happen depends on the buffer -- a TUI on the alternate screen holds its
+    own history and only it can move it, so the panel routes through
+    pageScrollAction rather than always moving the local viewport."""
     template = os.path.join(
         os.path.dirname(__file__), "..", "src", "templates", "terminal.html"
     )
@@ -248,11 +249,11 @@ def test_mobile_toolbar_can_reach_the_tiles_scrollback():
 
     assert 'data-scroll="-1"' in body and 'data-scroll="1"' in body
     assert "target.scrollPage(Number(btn.dataset.scroll));" in body
-    # The scroll buttons must not be reachable as byte-sending keys.
+    # The scroll buttons route through scrollPage, not the byte-sending key path.
     idx = body.index('toolbar.addEventListener("click"')
     handler = body[idx : idx + 900]
     assert handler.index("dataset.scroll") < handler.index("sendBytes")
-    assert "TerminalRouting.pageScrollLines(term.rows)" in body
+    assert "TerminalRouting.pageScrollAction(" in body
 
     css_path = os.path.join(
         os.path.dirname(__file__), "..", "src", "static", "style.css"


### PR DESCRIPTION
The mobile scrollback was still dead because it was scrolling the wrong thing. Claude's TUI takes the alternate screen buffer on startup (ESC[?1049h) and enables SGR mouse reporting; an alternate buffer has no scrollback, so xterm's scrollLines had nothing to move and the viewport had no overflow to drag. PgUp/PgDn and finger pans appeared to do nothing.

The history lives in the program's own scroll region, so on the alt buffer the page keys go down the wire (ESC[5~ / ESC[6~) and a finger drag becomes the wheel reports the TUI already turned on for itself, carrying any sub-notch remainder so slow drags aren't dropped. On the normal buffer the tile still owns its scrollback and scrolls locally, untouched. pageScrollAction decides per buffer.

Tests: node routing cases for pageScrollAction/wheelReport/dragWheelSteps, plus a real-browser playwright suite that drives an alt-screen greeting and asserts the actual bytes on the socket. 129 pytest + 26 node green.