### PR TITLE
terminal: preserve the open session across refreshes via URL fragment

### DIFF
--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -200,7 +200,48 @@
         return {steps: Math.abs(n), dir: n > 0 ? -1 : 1, consumed: n * step};
     }
 
+    /**
+     * The session ids named in a URL fragment, in order.
+     *
+     * The fragment is the shareable, per-tab record of what a tile is
+     * showing: `#s=id1,id2`. A fragment because it never reaches the
+     * server, so it rides through Cloudflare and the reverse proxy
+     * untouched and needs no route. Each browser tab carries its own, so
+     * two tabs restore independently with no coordination.
+     *
+     * @param {string} hash  location.hash, with or without the leading #
+     * @returns {string[]}   ids, empty on anything malformed
+     */
+    function parseOpenFragment(hash) {
+        try {
+            var m = /(?:^|[#&])s=([^&]*)/.exec(String(hash || ""));
+            if (!m) return [];
+            return decodeURIComponent(m[1])
+                .split(",")
+                .map(function (s) { return s.trim(); })
+                .filter(Boolean);
+        } catch (e) {
+            return [];
+        }
+    }
+
+    /**
+     * The fragment string for a set of open session ids.
+     *
+     * Empty in, empty out — a tile-less stage carries no fragment rather
+     * than a bare `#s=`, so closing the last tile leaves a clean URL.
+     *
+     * @param {string[]} ids
+     * @returns {string}  e.g. "#s=a,b" or ""
+     */
+    function formatOpenFragment(ids) {
+        var list = (ids || []).filter(Boolean);
+        return list.length ? "#s=" + list.map(encodeURIComponent).join(",") : "";
+    }
+
     root.TerminalRouting = {
+        parseOpenFragment: parseOpenFragment,
+        formatOpenFragment: formatOpenFragment,
         pageScrollLines: pageScrollLines,
         pageScrollAction: pageScrollAction,
         wheelReport: wheelReport,

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -91,10 +91,25 @@
     }
 
     // ── open-set persistence (restore the grid across reloads) ─────
+    // The URL fragment is the primary record — it survives a refresh in a
+    // per-tab, shareable way and rides through the proxy untouched (see
+    // TerminalRouting.parseOpenFragment). localStorage stays as a warm
+    // cache and the pre-fragment migration source.
+    function writeOpenFragment(ids) {
+        const frag = TerminalRouting.formatOpenFragment(ids);
+        const url = location.pathname + location.search + frag;
+        try { history.replaceState(null, "", url); } catch (e) {}
+    }
     function saveOpenSet() {
-        try { localStorage.setItem("term-open", JSON.stringify(Array.from(openPanels.keys()))); } catch (e) {}
+        const ids = Array.from(openPanels.keys());
+        try { localStorage.setItem("term-open", JSON.stringify(ids)); } catch (e) {}
+        writeOpenFragment(ids);
     }
     function recalledOpenSet() {
+        // Fragment wins; fall back to the localStorage cache for a tab that
+        // was opened before the fragment existed.
+        const fromUrl = TerminalRouting.parseOpenFragment(location.hash);
+        if (fromUrl.length) return fromUrl;
         try { return JSON.parse(localStorage.getItem("term-open") || "[]") || []; } catch (e) { return []; }
     }
 
@@ -1043,21 +1058,26 @@
     showView("list");
     syncLabelsFromServer();
     refreshSessions().then(function (rows) {
-        // Desktop: reopen the previously-open grid (or fall back to the most
-        // recent active session so the stage isn't empty). Mobile lands on
-        // the list.
-        if (!isWide()) return;
         const active = (rows || []).filter(function (r) { return isActiveStatus(r.status); });
         const byId = {};
         active.forEach(function (r) { byId[r.id] = r; });
-        let opened = 0;
-        recalledOpenSet().forEach(function (id) {
-            const hit = byId[id];
-            if (!hit) return;
+        const wanted = recalledOpenSet().map(function (id) { return byId[id]; }).filter(Boolean);
+        // Mobile is single-panel: a refresh restores the one session the
+        // fragment names rather than dumping the user back on the list. No
+        // named session (or it went inactive) leaves the list showing.
+        if (!isWide()) {
+            if (wanted.length) {
+                const hit = wanted[0];
+                addPanel({id: hit.id, mind_id: hit.mind_id, mind_name: hit.mind_name, status: hit.status});
+            }
+            return;
+        }
+        // Desktop: reopen the whole recalled grid, or fall back to the most
+        // recent active session so the stage isn't empty on a first visit.
+        wanted.forEach(function (hit) {
             addPanel({id: hit.id, mind_id: hit.mind_id, mind_name: hit.mind_name, status: hit.status});
-            opened += 1;
         });
-        if (opened === 0 && active.length > 0) {
+        if (wanted.length === 0 && active.length > 0) {
             const first = active[0];
             addPanel({id: first.id, mind_id: first.mind_id, mind_name: first.mind_name, status: first.status});
         }

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -16,7 +16,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
 const {
     pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText, pageScrollLines,
-    pageScrollAction, wheelReport, dragWheelSteps,
+    pageScrollAction, wheelReport, dragWheelSteps, parseOpenFragment, formatOpenFragment,
 } = globalThis.TerminalRouting;
 
 const tests = {
@@ -221,6 +221,27 @@ const tests = {
         // the tile ignore the gesture entirely.
         assert.deepEqual(dragWheelSteps(20, 24), {steps: 0, dir: 1, consumed: 0});
         assert.equal(dragWheelSteps(0, 24).steps, 0);
+    },
+
+    "the open fragment round-trips a set of session ids"() {
+        assert.equal(formatOpenFragment(["a", "b"]), "#s=a,b");
+        assert.deepEqual(parseOpenFragment("#s=a,b"), ["a", "b"]);
+        assert.deepEqual(parseOpenFragment(formatOpenFragment(["one", "two"])), ["one", "two"]);
+    },
+
+    "an empty open set carries no fragment"() {
+        // A tile-less stage must leave a clean URL, not a bare #s=.
+        assert.equal(formatOpenFragment([]), "");
+        assert.equal(formatOpenFragment(["", null]), "");
+        assert.deepEqual(parseOpenFragment(""), []);
+        assert.deepEqual(parseOpenFragment("#"), []);
+        assert.deepEqual(parseOpenFragment("#other=1"), []);
+    },
+
+    "fragment parsing tolerates a leading hash or none, and stray commas"() {
+        assert.deepEqual(parseOpenFragment("s=a,b"), ["a", "b"]);
+        assert.deepEqual(parseOpenFragment("#s=a,,b, "), ["a", "b"]);
+        assert.deepEqual(parseOpenFragment(null), []);
     },
 
     "an empty or exhausted box owes nothing"() {

--- a/tests/test_terminal_url_state.py
+++ b/tests/test_terminal_url_state.py
@@ -1,0 +1,175 @@
+"""A refresh must land back on the open session, not the agent list.
+
+The terminal records what a tile is showing in the URL fragment
+(`#s=<id>`), updated with replaceState as tiles open and close. On a phone
+that is the difference between a refresh dropping the user back on the
+agent list and a refresh reopening the session they were reading. A real
+browser because the whole point is that the fragment survives a full page
+navigation and drives the boot path.
+"""
+
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+playwright_api = pytest.importorskip(
+    "playwright.sync_api", reason="playwright is not installed"
+)
+
+import auth  # noqa: E402
+import main as main_mod  # noqa: E402
+
+PHONE = {"width": 412, "height": 780}
+SESSIONS = [
+    {
+        "id": "sess-alpha",
+        "mind_id": "mind-uuid",
+        "mind_name": "skippy",
+        "status": "running",
+        "short_id": "alpha",
+    },
+    {
+        "id": "sess-beta",
+        "mind_id": "mind-uuid",
+        "mind_name": "skippy",
+        "status": "running",
+        "short_id": "beta",
+    },
+]
+
+
+@pytest.fixture(scope="module")
+def live_app():
+    tmp = tempfile.mkdtemp()
+    os.environ["STB_DB_PATH"] = os.path.join(tmp, "stb.db")
+    os.environ["STB_SECRET_KEY"] = "browser-test-secret"
+
+    import uvicorn
+
+    user = auth.create_user("browser-test", "browser-pass", is_admin=True, replace=True)
+    token = auth.create_session_token(user)
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server = uvicorn.Server(
+        uvicorn.Config(main_mod.app, host="127.0.0.1", port=port, log_level="error")
+    )
+    threading.Thread(target=server.run, daemon=True).start()
+    for _ in range(100):
+        try:
+            socket.create_connection(("127.0.0.1", port), 0.2).close()
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        pytest.skip("app did not come up")
+
+    yield f"http://127.0.0.1:{port}", token
+    server.should_exit = True
+
+
+def _wire(page):
+    page.route(
+        "**/api/terminal/sessions*",
+        lambda r: r.fulfill(
+            status=200, content_type="application/json", body=json.dumps(SESSIONS)
+        ),
+    )
+    page.route(
+        "**/api/terminal/labels*",
+        lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
+    )
+    page.route_web_socket(
+        "**/api/terminal/attach/**",
+        lambda ws: ws.send("skippy@box:~$ ready"),
+    )
+
+
+def _mobile_ctx(browser, token):
+    ctx = browser.new_context(
+        viewport=PHONE, device_scale_factor=2.625, is_mobile=True, has_touch=True
+    )
+    ctx.add_cookies(
+        [
+            {
+                "name": auth.SESSION_COOKIE_NAME,
+                "value": token,
+                "domain": "127.0.0.1",
+                "path": "/",
+            }
+        ]
+    )
+    return ctx
+
+
+def test_opening_a_session_writes_it_to_the_fragment(live_app):
+    base, token = live_app
+    with playwright_api.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        page = _mobile_ctx(browser, token).new_page()
+        _wire(page)
+        page.goto(base + "/terminal")
+        page.wait_for_selector(".term-card", timeout=15000)
+        # No tile open yet: clean URL, no fragment.
+        assert "#s=" not in page.url
+
+        page.click(".term-card >> nth=0")
+        page.wait_for_selector(".term-panel .xterm-viewport", timeout=15000)
+        assert page.evaluate("() => location.hash") == "#s=sess-alpha"
+
+        # Backing out clears it again rather than leaving a stale #s=.
+        page.click(".term-panel-back")
+        page.wait_for_timeout(200)
+        assert page.evaluate("() => location.hash") == ""
+        browser.close()
+
+
+def test_a_refresh_reopens_the_fragment_session_on_mobile(live_app):
+    base, token = live_app
+    with playwright_api.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        page = _mobile_ctx(browser, token).new_page()
+        _wire(page)
+        # Land straight on a deep link, as a refresh with a set fragment does.
+        page.goto(base + "/terminal#s=sess-beta")
+        page.wait_for_selector(".term-panel .xterm-viewport", timeout=15000)
+        info = page.text_content(".term-panel-info")
+        assert "beta" in info or "skippy" in info
+        # The stage is up, not the list.
+        assert page.evaluate("() => document.getElementById('term-app').dataset.view") == "stage"
+        browser.close()
+
+
+def test_a_fragment_naming_a_dead_session_falls_back_to_the_list(live_app):
+    base, token = live_app
+    with playwright_api.sync_playwright() as p:
+        try:
+            browser = p.chromium.launch()
+        except Exception as exc:
+            pytest.skip(f"chromium unavailable: {exc}")
+        page = _mobile_ctx(browser, token).new_page()
+        _wire(page)
+        page.goto(base + "/terminal#s=sess-ghost")
+        page.wait_for_selector(".term-card", timeout=15000)
+        page.wait_for_timeout(400)
+        # Nothing to reopen: the list shows rather than a blank stage.
+        assert page.evaluate("() => document.getElementById('term-app').dataset.view") == "list"
+        assert page.query_selector(".term-panel") is None
+        browser.close()


### PR DESCRIPTION
Refreshing the terminal on a phone dropped you back on the agent list because the boot path only restored the grid on desktop. The open set now lives in the URL fragment (#s=<id>[,<id>...]), updated with history.replaceState as tiles open, switch, and close.

A fragment specifically: it never reaches the server, so it rides through Cloudflare and the reverse proxy untouched and needs no new route, and it is per-tab by nature, so two tabs on two different sessions each restore themselves with no coordination. The single-attachment pty guard is unchanged, so two tabs pointing at the same session still resolve exactly as before (the second evicts the first). Mobile is single-panel and reopens the one named session; desktop reopens the whole recalled grid, fragment-first with the old localStorage set as the migration fallback. A fragment naming a session that has since died falls back to the list rather than a blank stage.

Tests: node round-trip and edge cases for parseOpenFragment/formatOpenFragment, plus a real-browser playwright suite covering fragment write on open, restore-on-refresh, clear-on-back, and dead-session fallback. 132 pytest + 29 node green.