### PR TITLE
terminal: stop mobile IME from re-echoing typed and deleted text

### DIFF
--- a/src/static/terminal-routing.js
+++ b/src/static/terminal-routing.js
@@ -126,6 +126,30 @@
     }
 
     /**
+     * Whether xterm's hidden composition textarea should be emptied now that
+     * a burst of input has been committed to the pty.
+     *
+     * The textarea is xterm's model of "the current line", diffed against its
+     * previous value on every change (grew -> send the appended tail, shrank
+     * -> send one DEL). But a TUI like claude owns the real line, not xterm.
+     * Left to accumulate, the box carries the whole line, and a mobile
+     * keyboard's autocorrect, prediction, or multi-character backspace
+     * rewrites text the pty already has — the diff then re-slices that stale
+     * region and echoes it a second time (the "keys repeat, deleted
+     * characters come back" bug). Emptying the box after each committed burst
+     * makes the next keystroke diff from nothing, so nothing can be re-sent.
+     *
+     * Never mid-composition: while a word is still being typed the box holds
+     * it, and clearing would drop the word in progress.
+     *
+     * @param {Object} state {composing: boolean}
+     * @returns {boolean} true when the accumulator should be reset to empty
+     */
+    function shouldResetImeAccumulator(state) {
+        return !!(state && state.composing !== true);
+    }
+
+    /**
      * How far one press of the tile's PgUp/PgDn moves the viewport.
      *
      * A whole screen at a time loses the reader's place, so two rows of
@@ -251,5 +275,6 @@
         retryDelayMs: retryDelayMs,
         contrastText: contrastText,
         pendingImeText: pendingImeText,
+        shouldResetImeAccumulator: shouldResetImeAccumulator,
     };
 })(typeof globalThis !== "undefined" ? globalThis : this);

--- a/src/templates/terminal.html
+++ b/src/templates/terminal.html
@@ -571,6 +571,33 @@
         }
         term.onData(sendRaw);
 
+        // xterm's hidden composition textarea is its model of "the current
+        // line": every change is diffed against the box's prior value, and
+        // the difference is what goes to the pty. That works for a shell
+        // xterm draws itself, but here a TUI (claude) owns the line, and the
+        // box is never cleared between words. Left to accumulate, it holds
+        // the whole line, and a mobile keyboard's autocorrect, prediction, or
+        // multi-character backspace rewrites text the pty already has — the
+        // diff then re-emits that stale region and the pty echoes it twice,
+        // which is the "keys repeat, deleted characters come back" report.
+        // Emptying the box after every committed burst (never mid-word, where
+        // it still holds what's being typed) makes each burst diff from an
+        // empty base, so nothing already sent can be sent again.
+        function resetImeAccumulator() {
+            const helper = term._core && term._core._compositionHelper;
+            if (helper && !TerminalRouting.shouldResetImeAccumulator({composing: helper._isComposing})) {
+                return;
+            }
+            const ta = term.textarea;
+            if (ta && ta.value) ta.value = "";
+            if (helper) {
+                helper._dataAlreadySent = "";
+                const pos = helper._compositionPosition;
+                if (pos) { pos.start = 0; pos.end = 0; }
+            }
+        }
+        term.onData(resetImeAccumulator);
+
         // Scrolling by finger. On the alternate buffer — which is where
         // the TUI lives, and so the only buffer this tile ever really
         // shows — the viewport has no overflow, so the browser has

--- a/tests/js/terminal_routing_test.mjs
+++ b/tests/js/terminal_routing_test.mjs
@@ -15,7 +15,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 // <script> tag would, against globalThis.
 new Function(readFileSync(join(here, "..", "..", "src", "static", "terminal-routing.js"), "utf8"))();
 const {
-    pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText, pageScrollLines,
+    pickReattachTarget, isActive, retryDelayMs, contrastText, pendingImeText, shouldResetImeAccumulator, pageScrollLines,
     pageScrollAction, wheelReport, dragWheelSteps, parseOpenFragment, formatOpenFragment,
 } = globalThis.TerminalRouting;
 
@@ -177,6 +177,23 @@ const tests = {
         // length and so must this.
         const state = {composing: true, flushPending: false, start: 6, alreadySent: "wo"};
         assert.equal(pendingImeText(state, "hello world"), "rld");
+    },
+
+    "the IME accumulator is emptied once a burst has committed"() {
+        // Between words the box is settled; clearing it stops the next
+        // keystroke from diffing against a line the pty already holds.
+        assert.equal(shouldResetImeAccumulator({composing: false}), true);
+    },
+
+    "the IME accumulator is left alone mid-composition"() {
+        // The word being typed still lives in the box; clearing it now drops
+        // the in-progress word.
+        assert.equal(shouldResetImeAccumulator({composing: true}), false);
+    },
+
+    "an unknown composition state is left untouched"() {
+        assert.equal(shouldResetImeAccumulator(null), false);
+        assert.equal(shouldResetImeAccumulator(undefined), false);
     },
 
     "on the alternate buffer a page of scrolling is the program's to do"() {


### PR DESCRIPTION
The web terminal doubled typed characters on mobile, and backspacing then typing one key brought the deleted characters back.

## Root cause

xterm's hidden composition textarea is its model of the current line: every change is diffed against the box's prior value (`_handleAnyTextareaChanges` -> `t.replace(e,"")` plus length compare) and the difference is sent to the pty. That box was only ever emptied on Enter, so across a line it accumulates the whole line. A TUI like claude owns the real line, not xterm, and a mobile keyboard's autocorrect, prediction, or multi-character backspace rewrites text the pty already holds. The diff then re-slices that stale region and the pty echoes it a second time.

## Fix

Empty the composition textarea (and zero its sent-offset bookkeeping) after every committed input burst, never mid-composition where the box still holds the word being typed. Each burst then diffs from an empty base, so nothing already sent can be re-sent. The decision is factored into the pure, tested `shouldResetImeAccumulator` in terminal-routing.js. The existing Enter-time flush path is unchanged and still handles a composition open at Enter.

## Tests

Three node cases for the new helper; full suite 132 pytest and 32 node green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)