### PR TITLE
Showcase the inference proxy capability

### DIFF
--- a/src/static/style.css
+++ b/src/static/style.css
@@ -1160,6 +1160,8 @@ nav ul li.user-controls {
 .hive-feature-icon { display: grid; place-items: center; width: 42px; height: 42px; margin-bottom: 3.5rem; border: 1px solid rgba(80,229,239,.25); border-radius: 50%; color: var(--hive-cyan); font-size: 1.25rem; }
 .hive-feature h3 { margin-bottom: .8rem; font-size: 1.35rem; }
 .hive-feature p { max-width: 600px; color: #80969c; font-family: system-ui, sans-serif; font-size: .87rem; line-height: 1.65; }
+.hive-feature-link { display: inline-flex; gap: .4rem; margin-top: 1rem; color: var(--hive-cyan); font-size: .68rem; text-decoration: none; }
+.hive-feature-link:hover { color: #fff; }
 .hive-memory-demo, .hive-approval-demo { display: flex; align-items: center; gap: .65rem; margin-top: 1.4rem; color: #789198; font-size: .58rem; text-transform: uppercase; }
 .hive-memory-demo i { flex: 1; height: 1px; background: linear-gradient(90deg,var(--hive-cyan),transparent); }
 .hive-approval-demo { padding: .7rem; border: 1px solid var(--hive-line); border-radius: 4px; }

--- a/src/templates/hive_mind.html
+++ b/src/templates/hive_mind.html
@@ -38,7 +38,7 @@
             <div class="hive-live-metrics">
                 <div><strong>9</strong><span>minds</span></div>
                 <div><strong>4</strong><span>edge minds</span></div>
-                <div><strong>5</strong><span>capability nodes</span></div>
+                <div><strong>6</strong><span>capability nodes</span></div>
                 <div><strong>4</strong><span>live sessions</span></div>
             </div>
         </aside>
@@ -61,7 +61,7 @@
             <div class="hive-browser-bar"><span></span><span></span><span></span><code>hive.sparktobloom.com/overview</code><b>LIVE</b></div>
             <img src="/static/images/hive/overview.png" alt="Hive control center showing nine registered minds, edge minds, capability nodes, active sessions, and core service health" loading="lazy">
         </figure>
-        <div class="hive-caption-row"><span>Actual production interface</span><span>9 minds · 4 edges · 5 capabilities · 4 active sessions</span></div>
+        <div class="hive-caption-row"><span>Actual production interface</span><span>9 minds · 4 edges · 6 capabilities · 4 active sessions</span></div>
     </section>
 
     <section class="hive-terminal-section">
@@ -96,6 +96,7 @@
             <article class="hive-feature"><span class="hive-feature-num">03</span><div class="hive-feature-icon">◉</div><h3>Model freedom</h3><p>Run Codex, Claude, or local Ollama-backed minds together. The identity belongs to the mind, not the provider.</p></article>
             <article class="hive-feature"><span class="hive-feature-num">04</span><div class="hive-feature-icon">⌁</div><h3>Everywhere you are</h3><p>Keep the same conversation moving through Telegram, Discord, voice, and the browser terminal.</p></article>
             <article class="hive-feature hive-feature-wide"><span class="hive-feature-num">05</span><div class="hive-feature-icon">✓</div><h3>Autonomy with a brake pedal</h3><p>Scheduled work, proactive skills, and remote actions meet explicit human approval at the moments that matter.</p><div class="hive-approval-demo"><span>Agent requests action</span><b>REVIEW</b><button type="button" tabindex="-1">Approve once</button></div></article>
+            <article class="hive-feature"><span class="hive-feature-num">06</span><div class="hive-feature-icon">⇄</div><h3>One inference gateway</h3><p>The optional Inference Proxy gives every mind one private endpoint for hosted models, issued client keys, routing, and usage accounting. Its audited source is public and cloneable from the Control Center.</p><a class="hive-feature-link" href="https://github.com/danielstewart77/inference-proxy" target="_blank" rel="noopener">View the proxy source <span>↗</span></a></article>
         </div>
     </section>
 

--- a/tests/test_misc_routes.py
+++ b/tests/test_misc_routes.py
@@ -31,5 +31,8 @@ def test_hive_mind_showcase_is_public_and_links_from_home(tmp_path, monkeypatch)
     assert showcase.status_code == 200
     assert "One intelligence" in showcase.text
     assert "git clone https://github.com/danielstewart77/hive-mind.git" in showcase.text
+    assert "One inference gateway" in showcase.text
+    assert "https://github.com/danielstewart77/inference-proxy" in showcase.text
+    assert "6 capabilities" in showcase.text
     assert "/static/images/hive/terminal-grid.png" in showcase.text
     assert 'href="/hive-mind"' in home.text


### PR DESCRIPTION
Adds the public Inference Proxy to the Hive Mind project showcase, updates the live capability count, links its source, and covers the public page.